### PR TITLE
0.8.4 has 3 new Strut selection commands

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'eclipse'
 //apply plugin: 'antlr4'
 
 group = 'com.vzome.core'
-version = '0.8.3'
+version = '0.8.4'
 
 description = "vzome-core"
 
@@ -74,6 +74,7 @@ dependencies {
 gradle.projectsEvaluated {
 	tasks.withType(JavaCompile) {
 		options.compilerArgs \
+		<< "-Xdiags:verbose" \
 		<< "-Xlint:all" \
 		<< "-Xlint:cast" \
 		<< "-Xlint:divzero" \

--- a/src/main/java/com/vzome/core/algebra/AlgebraicVector.java
+++ b/src/main/java/com/vzome/core/algebra/AlgebraicVector.java
@@ -98,13 +98,21 @@ public final class AlgebraicVector implements Comparable<AlgebraicVector>
     }
 
     /**
-     * @return Returns a String with no extended characters so it's suitable for writing 
+     * @return A String with no extended characters so it's suitable for writing
      * to an 8 bit stream such as System.out or an ASCII text log file in Windows.
      * Contrast this with {@link toString()} which contains extended characters (e.g. \u03C4 (phi))
      */
     public final String toASCIIString()
     {
         return this .getVectorExpression( AlgebraicField .EXPRESSION_FORMAT );
+    }
+
+    /**
+     * @return A String representation that can be persisted to XML and parsed by XmlSaveFormat.parseRationalVector().
+     */
+    public final String toParsableString()
+    {
+        return this .getVectorExpression( AlgebraicField .ZOMIC_FORMAT );
     }
 
     @Override
@@ -251,6 +259,14 @@ public final class AlgebraicVector implements Comparable<AlgebraicVector>
             return this .coordinates[ i ] .dividedBy( unit .coordinates[ i ] );
         }
         throw new IllegalStateException( "vector is the origin!" );
+    }
+    
+    public static AlgebraicVector getNormal(final AlgebraicVector v0, final AlgebraicVector v1, final AlgebraicVector v2) {
+        return v1.minus(v0).cross(v2.minus(v0));
+    }
+
+    public static boolean areCollinear(final AlgebraicVector v0, final AlgebraicVector v1, final AlgebraicVector v2) {
+        return getNormal(v0, v1, v2).isOrigin();
     }
 
     public AlgebraicField getField()

--- a/src/main/java/com/vzome/core/editor/ChangeSelection.java
+++ b/src/main/java/com/vzome/core/editor/ChangeSelection.java
@@ -23,7 +23,7 @@ public abstract class ChangeSelection extends SideEffects
     
     private boolean groupingDoneInSelection;
 
-    private static final Logger logger = Logger.getLogger( "com.vzome.core.editor.ChangeSelection" );
+    protected static final Logger logger = Logger.getLogger( "com.vzome.core.editor.ChangeSelection" );
 
     ChangeSelection( Selection selection, boolean groupInSelection )
     {

--- a/src/main/java/com/vzome/core/editor/DocumentModel.java
+++ b/src/main/java/com/vzome/core/editor/DocumentModel.java
@@ -46,13 +46,13 @@ import com.vzome.core.construction.Polygon;
 import com.vzome.core.construction.Segment;
 import com.vzome.core.construction.SegmentCrossProduct;
 import com.vzome.core.construction.SegmentJoiningPoints;
+import com.vzome.core.editor.SelectSimilarSizeStruts.ComparisonModeEnum;
 import com.vzome.core.editor.Snapshot.SnapshotAction;
 import com.vzome.core.exporters.DaeExporter;
 import com.vzome.core.exporters.Exporter3d;
 import com.vzome.core.exporters.OpenGLExporter;
 import com.vzome.core.exporters.POVRayExporter;
 import com.vzome.core.exporters.PartGeometryExporter;
-import com.vzome.core.exporters.VRMLExporter;
 import com.vzome.core.math.DomUtils;
 import com.vzome.core.math.Projection;
 import com.vzome.core.math.RealVector;
@@ -361,7 +361,21 @@ public class DocumentModel implements Snapshot .Recorder, UndoableEdit .Context,
 		else if ( "SelectSimilarSize".equals( name ) )
 		{
 		    SymmetrySystem symmetry = this .symmetrySystems .get( xml .getAttribute( "symmetry" ) );
-            edit = new SelectSimilarSizeStruts( symmetry, null, null, this .mSelection, this .mRealizedModel );
+            edit = new SelectSimilarSizeStruts( symmetry, this .mSelection, this .mRealizedModel, ComparisonModeEnum.SAME_LENGTH );
+		}
+		else if ( "SelectParallelStruts".equals( name ) )
+		{
+		    SymmetrySystem symmetry = this .symmetrySystems .get( xml .getAttribute( "symmetry" ) );
+            edit = new SelectSimilarSizeStruts( symmetry, this .mSelection, this .mRealizedModel, ComparisonModeEnum.PARALLEL_TO_AXIS );
+		}
+		else if ( "SelectAutomaticStruts".equals( name ) )
+		{
+		    SymmetrySystem symmetry = this .symmetrySystems .get( xml .getAttribute( "symmetry" ) );
+            edit = new SelectAutomaticStruts( symmetry, this .mSelection, this .mRealizedModel );
+		}
+		else if ( "SelectCollinear".equals( name ) )
+		{
+            edit = new SelectCollinear( this .mSelection, this .mRealizedModel, groupInSelection );
 		}
 		else if ( "ValidateSelection".equals( name ) )
 			edit = new ValidateSelection( this.mSelection );
@@ -487,6 +501,14 @@ public class DocumentModel implements Snapshot .Recorder, UndoableEdit .Context,
             edit = mEditorModel.unselectStruts();
         else if ( action.equals( "selectNeighbors" ) )
             edit = mEditorModel.selectNeighbors();
+        else if ( action.equals( "SelectAutomaticStruts" ) )
+            edit = mEditorModel.selectAutomaticStruts(symmetrySystem);
+        else if ( action.equals( "SelectCollinear" ) )
+            edit = mEditorModel.selectCollinear();
+        else if ( action.equals( "SelectSimilarSize" ) )
+            edit = mEditorModel.selectSimilarSizeStruts(symmetrySystem);
+        else if ( action.equals( "SelectParallelStruts" ) )
+            edit = mEditorModel.selectParallelStruts(symmetrySystem);
         else if ( action.equals( "invertSelection" ) )
             edit = mEditorModel.invertSelection();
         else if ( action.equals( "group" ) )
@@ -636,9 +658,21 @@ public class DocumentModel implements Snapshot .Recorder, UndoableEdit .Context,
 		return new RealVector( 0, 0, 0 );
 	}
 
+    public void selectCollinear( AlgebraicVector vector1, AlgebraicVector vector2 )
+    {
+        UndoableEdit edit = new SelectCollinear( mSelection, mRealizedModel, false, vector1, vector2 );
+        this .performAndRecord( edit );
+    }
+    
+    public void selectParallelStruts( Direction orbit, Axis axis )
+    {
+        UndoableEdit edit = new SelectSimilarSizeStruts( this.symmetrySystem, mSelection, mRealizedModel, orbit, axis );
+        this .performAndRecord( edit );
+    }
+
     public void selectSimilarStruts( Direction orbit, AlgebraicNumber length )
     {
-        UndoableEdit edit = new SelectSimilarSizeStruts( this.symmetrySystem, orbit, length, mSelection, mRealizedModel );
+        UndoableEdit edit = new SelectSimilarSizeStruts( this.symmetrySystem, mSelection, mRealizedModel, orbit, length );
         this .performAndRecord( edit );
     }
     

--- a/src/main/java/com/vzome/core/editor/EditorModel.java
+++ b/src/main/java/com/vzome/core/editor/EditorModel.java
@@ -7,6 +7,7 @@ import com.vzome.core.commands.Command;
 import com.vzome.core.construction.Construction;
 import com.vzome.core.construction.Point;
 import com.vzome.core.construction.Segment;
+import com.vzome.core.editor.SelectSimilarSizeStruts.ComparisonModeEnum;
 import com.vzome.core.model.Connector;
 import com.vzome.core.model.Manifestation;
 import com.vzome.core.model.RealizedModel;
@@ -97,6 +98,24 @@ public class EditorModel
         else
             return new NoOp();
     }
+
+    public UndoableEdit selectAutomaticStruts(SymmetrySystem symmetry)
+    {
+        return new SelectAutomaticStruts(symmetry, mSelection, mRealized, false );
+    }
+
+    public UndoableEdit selectCollinear()
+    {
+        return new SelectCollinear(mSelection, mRealized, false );
+    }
+
+	public UndoableEdit selectSimilarSizeStruts(SymmetrySystem symmetry) {
+		return new SelectSimilarSizeStruts(symmetry, mSelection, mRealized, ComparisonModeEnum.SAME_LENGTH);
+	}
+
+	public UndoableEdit selectParallelStruts(SymmetrySystem symmetry) {
+		return new SelectSimilarSizeStruts(symmetry, mSelection, mRealized, ComparisonModeEnum.PARALLEL_TO_AXIS);
+	}
 
     public UndoableEdit invertSelection()
     {

--- a/src/main/java/com/vzome/core/editor/FilteredIterator.java
+++ b/src/main/java/com/vzome/core/editor/FilteredIterator.java
@@ -1,0 +1,141 @@
+package com.vzome.core.editor;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.function.Predicate;
+
+/**
+ * @author David Hall
+ * Based on http://stackoverflow.com/questions/5474893/how-to-implement-this-filteringiterator
+ */
+public abstract class FilteredIterator<T, R> implements Iterator<R>, Iterable<R> {
+
+    @Override
+    public Iterator<R> iterator() {
+        return this; // careful, don't return wrappedIterator
+    }
+
+    private final Iterator<T> wrappedIterator;
+    private final Predicate<T> preFilter;
+    private final Predicate<R> postFilter;
+    private R nextElement = null;
+    private Boolean hasNext = null; // determined on first use
+    
+    /**
+     * A convenience function that may be passed as a preFilter parameter
+     * @param <T>
+     * @param element
+     * @return {@code true} if element is not null
+     */
+    protected static <T> boolean ElementNotNull(T element) {
+        return element != null;
+    }
+
+    /**
+     * A convenience function that may be passed as a postFilter parameter
+     * @param <R>
+     * @param result
+     * @return {@code true} if result is not null
+     */
+    protected static <R> boolean ResultNotNull(R result) {
+        return result != null;
+    }
+
+    /**
+     * Elements must match this filter before conversion
+     * @param element
+     */
+    protected boolean preFilter(T element) {
+        return preFilter == null 
+                ? true
+                : preFilter.test(element);
+    }
+
+    /**
+     * Elements must match this filter after conversion
+     * @param element
+     */
+    protected boolean postFilter(R element) {
+        return postFilter == null 
+                ? true
+                : postFilter.test(element);
+    }
+    
+    /**
+     * Elements are converted from T to R. 
+     * T and R may be identical, related (e.g. sub-classed) or completely unrelated.
+     * @param element
+     */
+    protected abstract R convert(T element);
+
+    protected FilteredIterator(Iterable<T> iterable) {
+        this((Predicate<T>) null, iterable, (Predicate<R>) null);    
+    }
+
+    protected FilteredIterator(Predicate<T> preTest, Iterable<T> iterable) {
+        this(preTest, iterable, (Predicate<R>) null);    
+    }
+
+    protected FilteredIterator(Iterable<T> iterable, Predicate<R> postTest) {
+        this((Predicate<T>) null, iterable, postTest);    
+    }
+
+    /**
+     * Creates a new FilteredIterator by wrapping the iterator 
+     *  and returning only converted elements matching the filters.
+     * 
+     * @param preTest may be null to skip preTest;
+     * @param iterable
+     * @param postTest may be null to skip postTest;
+     */
+    protected FilteredIterator(Predicate<T> preTest, Iterable<T> iterable, Predicate<R> postTest) {
+        this.wrappedIterator = iterable.iterator();
+        preFilter = preTest;
+        postFilter = postTest;
+        // can't call nextMatch in any c'tor, because derived classes 
+        // may not be fully initialized yet and their filters may not work.this(preTest, iterable.iterator(), postTest);    
+    }
+
+    @Override
+    public boolean hasNext() {
+        if(hasNext == null) {
+            // first call after c'tor
+            nextMatch();
+        }
+        return hasNext;
+    }
+
+    @Override
+    public R next() {
+        if(hasNext == null) {
+            // first call after c'tor
+            nextMatch();
+        }
+        if (!hasNext) {
+            throw new NoSuchElementException();
+        }
+        return nextMatch();
+    }
+    
+    private R nextMatch() {
+        R lastMatch = nextElement;
+        while (wrappedIterator.hasNext()) {
+            T next = wrappedIterator.next();
+            if (preFilter(next)) {
+                R converted = convert(next);
+                if(postFilter(converted)) {
+                    nextElement = converted;
+                    hasNext = true;
+                    return lastMatch;
+                }
+            }
+        }
+        hasNext = false;
+        return lastMatch;
+    }
+    
+    @Override
+    public void remove() {
+        wrappedIterator.remove();
+    }
+}

--- a/src/main/java/com/vzome/core/editor/Manifestations.java
+++ b/src/main/java/com/vzome/core/editor/Manifestations.java
@@ -1,0 +1,103 @@
+package com.vzome.core.editor;
+
+import com.vzome.core.model.Connector;
+import com.vzome.core.model.Manifestation;
+import com.vzome.core.model.Panel;
+import com.vzome.core.model.Strut;
+import java.util.function.Predicate;
+
+/**
+ * @author David Hall
+ */
+public class Manifestations {
+    
+    public static boolean IsVisible(Manifestation man) {
+        return !man.isHidden();
+    }
+
+    // Manifestations
+    public static ManifestationIterator VisibleManifestations(Iterable<Manifestation> manifestations) {
+        return new ManifestationIterator(Manifestations::IsVisible, manifestations, null);
+    }
+    public static ManifestationIterator VisibleManifestations(Predicate<Manifestation> preTest, Iterable<Manifestation> manifestations) {
+        return new ManifestationIterator(preTest, manifestations, Manifestations::IsVisible);
+    }
+    public static ManifestationIterator VisibleManifestations(Iterable<Manifestation> manifestations, Predicate<Manifestation> postTest) {
+        return new ManifestationIterator(Manifestations::IsVisible, manifestations, postTest);
+    }
+    public static class ManifestationIterator extends FilteredIterator<Manifestation, Manifestation> {
+        public ManifestationIterator(Predicate<Manifestation> preTest, Iterable<Manifestation> manifestations, Predicate<Manifestation> postTest) {
+            super(preTest, manifestations, postTest);
+        }
+        @Override
+        protected Manifestation convert(Manifestation element) {
+            return element;
+        }
+    }
+    
+    // Connectors        
+    public static ConnectorIterator Connectors(Iterable<Manifestation> manifestations) {
+        return new ConnectorIterator(null, manifestations, null);
+    }
+    public static ConnectorIterator Connectors(Iterable<Manifestation> manifestations, Predicate<Connector> postFilter) {
+        return new ConnectorIterator(null, manifestations, postFilter);
+    }
+    public static ConnectorIterator Connectors(Predicate<Manifestation> preFilter, Iterable<Manifestation> manifestations, Predicate<Connector> postFilter) {
+        return new ConnectorIterator(preFilter, manifestations, postFilter);
+    }
+    public static ConnectorIterator VisibleConnectors(Iterable<Manifestation> manifestations) {
+        return VisibleConnectors(manifestations, null);
+    }
+    public static ConnectorIterator VisibleConnectors(Iterable<Manifestation> manifestations, Predicate<Connector> postFilter) {
+        return new ConnectorIterator(Manifestations::IsVisible, manifestations, postFilter);
+    }
+    public static class ConnectorIterator extends SubClassIterator<Manifestation, Connector> {
+        private ConnectorIterator(Predicate<Manifestation> preFilter, Iterable<Manifestation> manifestations, Predicate<Connector> postFilter) {
+            super(Connector.class, preFilter, manifestations, postFilter);
+        }
+    }
+
+    // Struts
+    public static StrutIterator Struts(Iterable<Manifestation> manifestations) {
+        return new StrutIterator(null, manifestations, null);
+    }
+    public static StrutIterator Struts(Iterable<Manifestation> manifestations, Predicate<Strut> postFilter) {
+        return new StrutIterator(null, manifestations, postFilter);
+    }
+    public static StrutIterator Struts(Predicate<Manifestation> preFilter, Iterable<Manifestation> manifestations, Predicate<Strut> postFilter) {
+        return new StrutIterator(preFilter, manifestations, postFilter);
+    }
+    public static StrutIterator VisibleStruts(Iterable<Manifestation> manifestations) {
+        return VisibleStruts(manifestations, null);
+    }
+    public static StrutIterator VisibleStruts(Iterable<Manifestation> manifestations, Predicate<Strut> postFilter) {
+        return new StrutIterator(Manifestations::IsVisible, manifestations, postFilter);
+    }
+    public static class StrutIterator extends SubClassIterator<Manifestation, Strut> {
+        private StrutIterator(Predicate<Manifestation> preFilter, Iterable<Manifestation> manifestations, Predicate<Strut> postFilter) {
+            super(Strut.class, preFilter, manifestations, postFilter);
+        }
+    }
+
+    // Panels
+    public static PanelIterator Panels(Iterable<Manifestation> manifestations) {
+        return new PanelIterator(null, manifestations, null);
+    }
+    public static PanelIterator Panels(Iterable<Manifestation> manifestations, Predicate<Panel> postFilter) {
+        return new PanelIterator(null, manifestations, postFilter);
+    }
+    public static PanelIterator Panels(Predicate<Manifestation> preFilter, Iterable<Manifestation> manifestations, Predicate<Panel> postFilter) {
+        return new PanelIterator(preFilter, manifestations, postFilter);
+    }
+    public static PanelIterator VisiblePanels(Iterable<Manifestation> manifestations) {
+        return VisiblePanels(manifestations, null);
+    }
+    public static PanelIterator VisiblePanels(Iterable<Manifestation> manifestations, Predicate<Panel> postFilter) {
+        return new PanelIterator(Manifestations::IsVisible, manifestations, postFilter);
+    }
+    public static class PanelIterator extends SubClassIterator<Manifestation, Panel> {
+        private PanelIterator(Predicate<Manifestation> preFilter, Iterable<Manifestation> manifestations, Predicate<Panel> postFilter) {
+            super(Panel.class, preFilter, manifestations, postFilter);
+        }
+    }
+}

--- a/src/main/java/com/vzome/core/editor/SelectAutomaticStruts.java
+++ b/src/main/java/com/vzome/core/editor/SelectAutomaticStruts.java
@@ -1,0 +1,49 @@
+package com.vzome.core.editor;
+
+import com.vzome.core.commands.Command.Failure;
+import com.vzome.core.math.DomUtils;
+import com.vzome.core.model.RealizedModel;
+import com.vzome.core.model.Strut;
+import org.w3c.dom.Element;
+
+/**
+ * @author David Hall
+ */
+public class SelectAutomaticStruts extends SelectFromRealizedModel {
+
+	protected final SymmetrySystem symmetry;
+	
+	public SelectAutomaticStruts(SymmetrySystem symm, Selection selection, RealizedModel model) {
+		this(symm, selection, model, false);
+	}
+	
+	public SelectAutomaticStruts(SymmetrySystem symm, Selection selection, RealizedModel model, boolean groupInSelection) {
+		super(selection, model, groupInSelection);
+		this.symmetry = symm;
+	}
+	
+	@Override
+	public void perform() throws Failure {
+        unselectStruts();
+        for( Strut strut : VisibleStruts(this::isAutomaticStrut) ) {
+            select(strut);
+		}
+		super.perform();
+	}
+	
+    private boolean isAutomaticStrut(Strut strut) {
+        return symmetry.getAxis(strut.getOffset()).getOrbit().isAutomatic();
+    }
+    
+	@Override
+	protected String getXmlElementName() {
+		return "SelectAutomaticStruts";
+	}
+
+	@Override
+	protected void getXmlAttributes(Element element) {
+		if (symmetry != null) {
+			DomUtils.addAttribute(element, "symmetry", symmetry.getName());
+		}
+	}
+}

--- a/src/main/java/com/vzome/core/editor/SelectCollinear.java
+++ b/src/main/java/com/vzome/core/editor/SelectCollinear.java
@@ -1,0 +1,148 @@
+package com.vzome.core.editor;
+
+import com.vzome.core.algebra.AlgebraicVector;
+import com.vzome.core.commands.Command;
+import com.vzome.core.commands.Command.Failure;
+import com.vzome.core.commands.XmlSaveFormat;
+import static com.vzome.core.editor.ChangeSelection.logger;
+import com.vzome.core.math.DomUtils;
+import com.vzome.core.model.Connector;
+import com.vzome.core.model.RealizedModel;
+import com.vzome.core.model.Strut;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.logging.Level;
+import org.w3c.dom.Element;
+
+/**
+ * @author David Hall
+ */
+public class SelectCollinear extends SelectFromRealizedModel {
+
+    private AlgebraicVector vector1;
+    private AlgebraicVector vector2;
+    private boolean vectorsFromSelection = false;
+
+	/* 
+	* Called by the context menu. Inputs are the two end points of the strut associated with the context menu.
+	*/
+    public SelectCollinear(Selection selection, RealizedModel model, boolean groupInSelection, AlgebraicVector vector1, AlgebraicVector vector2) {
+        super(selection, model, groupInSelection);
+        this.vector1 = vector1;
+        this.vector2 = vector2;
+        vectorsFromSelection = false;
+    }
+
+	/* 
+	* Called by the main menu. Input is either the last selected strut or the last two selected balls.
+	*/
+    public SelectCollinear(Selection selection, RealizedModel model, boolean groupInSelection) {
+        super(selection, model, groupInSelection);
+        AlgebraicVector v1 = null;
+        AlgebraicVector v2 = null;
+        Strut lastStrut = null;
+        for (Strut strut : SelectedStruts()) {
+            lastStrut = strut;
+        }
+        if (lastStrut != null) {
+            v1 = lastStrut.getLocation();
+            v2 = lastStrut.getEnd();
+        } else {
+            for (Connector ball : SelectedConnectors()) {
+                // use the last two balls selected if a strut was not selected
+                v1 = v2;
+                v2 = ball.getLocation();
+            }
+        }
+        vector1 = v1;
+        vector2 = v2;
+        vectorsFromSelection = (vector1 != null && vector2 != null);
+    }
+
+    @Override
+    public void perform() throws Command.Failure {
+        if (vector1 != null && vector2 != null) {
+            unselectConnectors();
+            unselectStruts();
+
+            Set<Connector> balls = new TreeSet<>(); // auto sorted
+            // Example of using FilteredIterator with Predicate parameter.
+            for (Connector ball : VisibleConnectors(this::isCollinearWith)) { 
+                balls.add(ball);
+            }
+            
+            Set<Strut> struts = new TreeSet<>(); // auto sorted
+            // Example of conventional "if" syntax within the loop.
+            // Compare to the equivalent FilteredIterator predicate syntax above.
+            for (Strut strut : VisibleStruts()) {
+                if (isCollinearWith(strut)) {
+                    struts.add(strut);
+                }
+            }
+
+			// balls and struts to be selected are now in two sorted sets
+            // so we can select them in a consistent order, suitable
+            // for subsequent use by other tools such as JoinPoints
+            for (Connector ball : balls) {
+                select(ball);
+            }
+            for (Strut strut : struts) {
+                select(strut);
+            }
+
+            Level level = Level.FINER;
+            if (logger.isLoggable(level)) {
+                StringBuilder sb = new StringBuilder("Selected:\n");
+                final String indent = "  ";
+                for (Connector ball : balls) {
+                    sb.append(indent).append(ball.toString()).append("\n");
+                }
+                for (Strut strut : struts) {
+                    sb.append(indent).append(strut.toString()).append("\n");
+                }
+                logger.log(level, sb.toString());
+            }
+
+            super.perform();
+        }
+    }
+
+    private boolean isCollinearWith(Connector ball) {
+        return isCollinear(ball.getLocation());
+    }
+
+    private boolean isCollinearWith(Strut strut) {
+        return isCollinear(strut.getLocation())
+                && isCollinear(strut.getEnd());
+    }
+
+    private boolean isCollinear(AlgebraicVector vec) {
+        return AlgebraicVector.areCollinear(vec, vector1, vector2);
+    }
+
+    @Override
+    protected String getXmlElementName() {
+        return "SelectCollinear";
+    }
+
+    private static final String strVectorsFromSelectionATTR = "vectorsFromSelection";
+
+    @Override
+    protected void getXmlAttributes(Element element) {
+        DomUtils.addAttribute(element, strVectorsFromSelectionATTR, Boolean.toString(vectorsFromSelection));
+        if( !vectorsFromSelection ) {
+            // don't persist the vectors if they are derived from the selection
+            DomUtils.addAttribute(element, "vector1", vector1.toParsableString());
+            DomUtils.addAttribute(element, "vector2", vector2.toParsableString());
+        }
+    }
+
+    @Override
+    protected void setXmlAttributes(Element xml, XmlSaveFormat format) throws Failure {
+        vectorsFromSelection = Boolean.parseBoolean(xml.getAttribute(strVectorsFromSelectionATTR));
+        if(!vectorsFromSelection) {
+            this.vector1 = format.parseRationalVector(xml, "vector1");
+            this.vector2 = format.parseRationalVector(xml, "vector2");
+        }
+    }
+}

--- a/src/main/java/com/vzome/core/editor/SelectFromRealizedModel.java
+++ b/src/main/java/com/vzome/core/editor/SelectFromRealizedModel.java
@@ -1,0 +1,122 @@
+package com.vzome.core.editor;
+
+import com.vzome.core.editor.Manifestations.ConnectorIterator;
+import com.vzome.core.editor.Manifestations.PanelIterator;
+import com.vzome.core.editor.Manifestations.StrutIterator;
+import com.vzome.core.model.Connector;
+import com.vzome.core.model.Manifestation;
+import com.vzome.core.model.Panel;
+import com.vzome.core.model.RealizedModel;
+import com.vzome.core.model.Strut;
+import java.util.function.Predicate;
+
+/**
+ * @author David Hall
+ */
+public abstract class SelectFromRealizedModel extends ChangeSelection
+{
+	protected final RealizedModel mRealizedModel;
+
+	public SelectFromRealizedModel( Selection selection, RealizedModel realizedModel, boolean groupInSelection )
+    {
+		super(selection, groupInSelection);
+		mRealizedModel  = realizedModel;
+	}
+    
+    protected ConnectorIterator SelectedConnectors() {
+        return Manifestations.Connectors(mSelection);
+    }
+	
+    protected StrutIterator SelectedStruts() {
+        return Manifestations.Struts(mSelection);
+    }
+	
+    protected PanelIterator SelectedPanels() {
+        return Manifestations.Panels(mSelection);
+    }
+	
+    protected ConnectorIterator RealizedConnectors() {
+        return Manifestations.Connectors(mRealizedModel);
+    }
+	
+    protected StrutIterator RealizedStruts() {
+        return Manifestations.Struts(mRealizedModel);
+    }
+	
+    protected PanelIterator RealizedPanels() {
+        return Manifestations.Panels(mRealizedModel);
+    }
+    
+    protected ConnectorIterator VisibleConnectors() {
+        return Manifestations.VisibleConnectors(mRealizedModel);
+    }
+	
+    protected StrutIterator VisibleStruts() {
+        return Manifestations.VisibleStruts(mRealizedModel);
+    }
+	
+    protected PanelIterator VisiblePanels() {
+        return Manifestations.VisiblePanels(mRealizedModel);
+    }
+
+    protected ConnectorIterator VisibleConnectors(Predicate<Connector> postFilter) {
+        return Manifestations.VisibleConnectors(mRealizedModel, postFilter);
+    }
+	
+    protected StrutIterator VisibleStruts(Predicate<Strut> postFilter) {
+        return Manifestations.VisibleStruts(mRealizedModel, postFilter);
+    }
+	
+    protected PanelIterator VisiblePanels(Predicate<Panel> postFilter) {
+        return Manifestations.VisiblePanels(mRealizedModel, postFilter);
+    }
+	
+    public boolean unselectConnectors() {
+        boolean anySelected = false;
+        for( Connector connector : SelectedConnectors() ) {
+            anySelected = true;
+            this.unselect(connector);
+        }
+        if(anySelected) {
+            redo();
+        }
+        return anySelected;
+    }
+	
+    public boolean unselectAll() {
+        boolean anySelected = false;
+        for( Manifestation man : mSelection ) {
+            anySelected = true;
+            this.unselect(man);
+        }
+        if(anySelected) {
+            redo();
+        }
+        return anySelected;
+    }
+	
+    public boolean unselectStruts() {
+        boolean anySelected = false;
+        for( Strut strut : SelectedStruts() ) {
+            anySelected = true;
+            this.unselect(strut);
+        }
+        if(anySelected) {
+            redo();
+        }
+        return anySelected;
+    }
+	
+    public boolean unselectPanels() {
+        boolean anySelected = false;
+        for( Panel panel : SelectedPanels() ) {
+            anySelected = true;
+            this.unselect(panel);
+        }
+        if(anySelected) {
+            redo();
+        }
+        return anySelected;
+    }
+	
+}

--- a/src/main/java/com/vzome/core/editor/SelectSimilarSizeStruts.java
+++ b/src/main/java/com/vzome/core/editor/SelectSimilarSizeStruts.java
@@ -4,8 +4,6 @@
 package com.vzome.core.editor;
 
 
-import org.w3c.dom.Element;
-
 import com.vzome.core.algebra.AlgebraicNumber;
 import com.vzome.core.algebra.AlgebraicVector;
 import com.vzome.core.commands.Command.Failure;
@@ -13,46 +11,160 @@ import com.vzome.core.commands.XmlSaveFormat;
 import com.vzome.core.math.DomUtils;
 import com.vzome.core.math.symmetry.Axis;
 import com.vzome.core.math.symmetry.Direction;
+import com.vzome.core.math.symmetry.Symmetry;
 import com.vzome.core.model.Manifestation;
 import com.vzome.core.model.RealizedModel;
 import com.vzome.core.model.Strut;
+import java.util.logging.Level;
+import org.w3c.dom.Element;
 
 public class SelectSimilarSizeStruts extends ChangeSelection
-{
+{    
+    public enum ComparisonModeEnum {
+        SAME_LENGTH,
+        PARALLEL_TO_AXIS
+    }
+    
+    private ComparisonModeEnum comparisonMode;
     private Direction orbit;
+    private Axis zone;
     private AlgebraicNumber length;
-    private RealizedModel model;
-    private SymmetrySystem symmetry;
+    private final RealizedModel model;
+    private final SymmetrySystem symmetry;
 
-    public SelectSimilarSizeStruts( SymmetrySystem symmetry, Direction orbit, AlgebraicNumber length,
-            Selection selection, RealizedModel model )
+    // All public c'tors have the three common parameters first followed by context specific qualifiers
+
+    /**
+     * called by both selectSimilarSizeStruts and selectParallelStruts from the main menu
+     * @param symmetry
+     * @param selection
+     * @param model
+     * @param mode distinguishes the desired behavior of the command
+     */
+    public SelectSimilarSizeStruts(SymmetrySystem symmetry, Selection selection, RealizedModel model, 
+            ComparisonModeEnum mode)
     {
         super( selection, false );
         this.symmetry = symmetry;
-        this .model = model;
-        this .orbit = orbit;
-        this .length = length;
+        this.model = model;
+        this.comparisonMode = mode;
+        Strut lastStrut = null;
+        for (Manifestation man : mSelection) {
+            if (man.isRendered() && man instanceof Strut) {
+                lastStrut = (Strut) man;
+            }
+        }
+        if (lastStrut != null) {
+            AlgebraicVector offset = lastStrut.getOffset();
+            this.orbit = symmetry.getAxis(offset).getOrbit();
+            this.zone = orbit.getAxis(offset);
+            this.length = zone.getLength(offset);
+        } else {
+            this.orbit = null;
+            this.zone = null;
+            this.length = null;
+        }
     }
-
-    @Override
-    public void perform() throws Failure
+        
+    /**
+     * called by selectSimilarStruts from the strut context menu
+     * @param symmetry
+     * @param selection
+     * @param model
+     * @param orbit
+     * @param length
+     */
+    public SelectSimilarSizeStruts(SymmetrySystem symmetry, Selection selection, RealizedModel model, 
+            Direction orbit, AlgebraicNumber length)
     {
+        super( selection, false );
+        this.symmetry = symmetry;
+        this.model = model;
+        this.comparisonMode = ComparisonModeEnum.SAME_LENGTH;
+        this.orbit = orbit;
+        this.length = length;
+        this.zone = null;
+    }
+    
+    /**
+     * called by selectParallelStruts from the strut context menu
+     * @param symmetry
+     * @param selection
+     * @param model
+     * @param orbit
+     * @param axis
+     */
+    public SelectSimilarSizeStruts(SymmetrySystem symmetry, Selection selection, RealizedModel model, 
+            Direction orbit, Axis axis)
+    {
+        super( selection, false );
+        this.symmetry = symmetry;
+        this.model = model;
+        this.comparisonMode = ComparisonModeEnum.PARALLEL_TO_AXIS;
+        this.orbit = orbit;
+        this.zone = axis;
+        this.length = null;
+    }
+    
+	// Normal usage cases include both "Select Similar Size Struts" and "Select Parallel Struts" from:
+    // 1) Main menu with 1 or more struts selected (Last selected strut will be used as input)
+    // 2) Strut context menu
+    // 3) Undo and Redo operations
+    // 4) Reopening a saved vZome file (persisted as XML)
+    // 5) Reopening a previous version of vZome file with no comparisonMode specified.
+    //
+    // Ensure that we can safely do nothing (with no exceptions thrown) 
+    //   using both "Select Similar Size Struts" and "Select Parallel Struts" from:
+    // 1) Main menu with nothing selected
+    // 2) Main menu with balls and/or panels selected but no strut selected
+    @Override
+    public void perform() throws Failure {
+        deselectAllStruts();
+
+        Axis oppositeZone = null;
+        if(comparisonMode == ComparisonModeEnum.PARALLEL_TO_AXIS) {
+            int opposite = ( zone .getSense() + 1 ) % 2;
+            oppositeZone = orbit. getAxis( opposite, zone .getOrientation() );
+        }
+
         for (Manifestation man : model) {
-            if ( man .getRenderedObject() == null )
-                continue;  // hidden!
-            if ( man instanceof Strut ) {
+            if (man.isRendered() && man instanceof Strut ) {
                 Strut strut = (Strut) man;
                 AlgebraicVector offset = strut .getOffset();
-                Axis zone = symmetry .getAxis( offset );
-                Direction zoneOrbit = zone .getOrbit();
-                if ( zoneOrbit != this .orbit )
-                    continue;
-                AlgebraicNumber zoneLength = zone .getLength( offset );
-                if ( this .length .equals( zoneLength ) )
-                    select( strut );
+                Axis axis = symmetry.getAxis(offset);
+                if (axis != null && orbit == axis.getOrbit()) {
+                    switch (comparisonMode) {
+                        case SAME_LENGTH:
+                            if( axis.getLength(offset).equals(length) ) {
+                                select(strut);
+                            }
+                            break;
+                        case PARALLEL_TO_AXIS:
+                            if ( axis.equals(zone) || axis.equals(oppositeZone) ) {
+                                select(strut);
+                            }
+                            break;
+                        default:
+                            throw new UnsupportedOperationException("Unexpected Comparison Mode: " + comparisonMode.toString());
+                    }
+                }
             }
         }
         super .perform();
+    }
+
+    private void deselectAllStruts()
+    {
+        boolean anySelectedStruts = false;
+        for (Manifestation man : model) {
+            if (man.isRendered() && man instanceof Strut) {
+                anySelectedStruts = true;
+                unselect(man);
+            }
+        }
+        if (anySelectedStruts) {
+            redo();
+        }
     }
 
     @Override
@@ -61,13 +173,16 @@ public class SelectSimilarSizeStruts extends ChangeSelection
         return "SelectSimilarSize";
     }
 
+    private static final String attrComparisonMode = "comparisonMode"; // avoid typos
+
     @Override
     protected void getXmlAttributes( Element element )
     {
-        if ( symmetry != null )
-            DomUtils .addAttribute( element, "symmetry", symmetry .getName() );
-        if ( orbit != null )
-        	DomUtils .addAttribute( element, "orbit", orbit .getName() );
+        DomUtils .addAttribute( element, attrComparisonMode, comparisonMode.toString());
+        DomUtils .addAttribute( element, "symmetry", symmetry .getName() );
+        DomUtils .addAttribute( element, "orbit", orbit .getName() );
+        if ( zone != null )
+            zone.getXML(element);
         if ( length != null )
             XmlSaveFormat .serializeNumber( element, "length", length );
     }
@@ -76,7 +191,34 @@ public class SelectSimilarSizeStruts extends ChangeSelection
     protected void setXmlAttributes( Element xml, XmlSaveFormat format )
             throws Failure
     {
-        length = format .parseNumber( xml, "length" );
+        comparisonMode = ComparisonModeEnum.SAME_LENGTH;
+        String strAttr = xml.getAttribute(attrComparisonMode);
+        if(strAttr != null && !strAttr.isEmpty()) {
+            try {
+                comparisonMode = ComparisonModeEnum.valueOf(strAttr.trim());
+            }
+            catch(IllegalArgumentException ex) {
+                String msg = "'" + strAttr +
+                        "' is not a valid " + comparisonMode.getClass().getSimpleName()
+                        + ". Defaulting to " + comparisonMode + ".";
+                logger.log(Level.WARNING, msg, ex);
+            }
+        }
         orbit = symmetry .getOrbits() .getDirection( xml .getAttribute( "orbit" ) );
+        switch (comparisonMode) {
+            case SAME_LENGTH:
+                length = format .parseNumber( xml, "length" );
+                break;
+            case PARALLEL_TO_AXIS:
+                String strSense = xml.getAttribute("sense");
+                int sense = (strSense != null && "minus".equals(strSense.toLowerCase()))
+                        ? Symmetry.MINUS
+                        : Symmetry.PLUS;
+                int index = Integer.parseInt(xml.getAttribute("index"));
+                this.zone = orbit.getAxis(sense, index);
+                break;
+            default:
+                throw new UnsupportedOperationException("Unexpected Comparison Mode: " + comparisonMode.toString());
+        }
     }
 }

--- a/src/main/java/com/vzome/core/editor/SubClassIterator.java
+++ b/src/main/java/com/vzome/core/editor/SubClassIterator.java
@@ -1,0 +1,43 @@
+package com.vzome.core.editor;
+
+import java.util.function.Predicate;
+
+/**
+ * @author David Hall
+ */
+public class SubClassIterator<T, S extends T> extends FilteredIterator<T, S> {
+    
+    private final Class<S> subClass;
+
+    @Override
+    public boolean preFilter(T element) {
+        return (element != null && subClass.isAssignableFrom(element.getClass()))
+                ? super.preFilter(element)
+                : false;
+    }
+    
+    @Override
+    protected S convert(T element) {
+        return subClass.cast(element);
+    }
+
+    public SubClassIterator(Class<S> subClass, Iterable<T> iterable) {
+        super(iterable);
+        this.subClass = subClass;
+    }
+    
+    public SubClassIterator(Class<S> subClass, Predicate<T> preTest, Iterable<T> iterable) {
+        super(preTest, iterable);
+        this.subClass = subClass;
+    }
+    
+    public SubClassIterator(Class<S> subClass, Iterable<T> iterable, Predicate<S> postTest) {
+        super(iterable, postTest);
+        this.subClass = subClass;
+    }
+    
+    public SubClassIterator(Class<S> subClass, Predicate<T> preTest, Iterable<T> iterable, Predicate<S> postTest) {
+        super(preTest, iterable, postTest);
+        this.subClass = subClass;
+    }
+}

--- a/src/main/java/com/vzome/core/math/symmetry/Axis.java
+++ b/src/main/java/com/vzome/core/math/symmetry/Axis.java
@@ -1,8 +1,6 @@
 package com.vzome.core.math.symmetry;
 
 
-import java.util.logging.Logger;
-
 import org.w3c.dom.Element;
 
 import com.vzome.core.algebra.AlgebraicNumber;
@@ -20,11 +18,11 @@ public class Axis
 
 	private final int mRotation;
     
-    private Permutation mRotationPerm;
+    private final Permutation mRotationPerm;
 
 	private final AlgebraicVector normal;   // not a unit vector
         
-    private static final Logger logger = Logger.getLogger( "com.vzome.core.math" );
+//    private static final Logger logger = Logger.getLogger( "com.vzome.core.math" );
 
 	Axis( Direction dir, int index, int sense, int rotation, Permutation rotPerm, AlgebraicVector normal )
 	{
@@ -123,7 +121,7 @@ public class Axis
     }
 
     /**
-     * @param plus
+     * @param sense
      * @param orientation2
      */
     public void rename( int sense, int orientation2 )

--- a/src/main/java/com/vzome/core/model/Panel.java
+++ b/src/main/java/com/vzome/core/model/Panel.java
@@ -6,19 +6,21 @@ import java.util.Iterator;
 import java.util.List;
 
 import com.vzome.core.algebra.AlgebraicVector;
+import java.util.ArrayList;
 
 public class Panel extends Manifestation implements Iterable<AlgebraicVector>
 {
     private final List<AlgebraicVector> mVertices;
 
     /**
-     * Create a panel from an iterator over AlgebraicVectors
+     * Create a panel from a list of AlgebraicVectors
      * 
      * @param vertices
      */
     public Panel( List<AlgebraicVector> vertices )
     {
-        mVertices = vertices;
+        // copy the list in case the caller modifies it later.
+        mVertices = new ArrayList<>(vertices);
     }
 
     @Override
@@ -40,6 +42,11 @@ public class Panel extends Manifestation implements Iterable<AlgebraicVector>
 	public Iterator<AlgebraicVector> iterator()
 	{
 		return mVertices.iterator();
+	}
+
+	public int getVertexCount()
+	{
+		return mVertices.size();
 	}
 
     @Override
@@ -119,9 +126,7 @@ public class Panel extends Manifestation implements Iterable<AlgebraicVector>
         AlgebraicVector v0 = mVertices.get( 0 );
         AlgebraicVector v1 = mVertices.get( 1 );
         AlgebraicVector v2 = mVertices.get( 2 );
-        v1 = v1 .minus( v0 );
-        v2 = v2 .minus( v0 );
-        return v1 .cross( v2 );
+        return AlgebraicVector.getNormal(v0, v1, v2);
     }
 
 	@Override

--- a/src/test/java/com/vzome/core/algebra/AlgebraicFieldTest.java
+++ b/src/test/java/com/vzome/core/algebra/AlgebraicFieldTest.java
@@ -2,7 +2,6 @@ package com.vzome.core.algebra;
 
 import java.util.HashSet;
 import java.util.Set;
-import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.*;
 import static junit.framework.TestCase.assertTrue;
 import org.junit.Test;

--- a/src/test/java/com/vzome/core/editor/ManifestationIteratorTest.java
+++ b/src/test/java/com/vzome/core/editor/ManifestationIteratorTest.java
@@ -1,0 +1,239 @@
+package com.vzome.core.editor;
+
+import com.vzome.core.algebra.AlgebraicField;
+import com.vzome.core.algebra.AlgebraicNumber;
+import com.vzome.core.algebra.AlgebraicVector;
+import com.vzome.core.algebra.PentagonField;
+import com.vzome.core.model.Connector;
+import com.vzome.core.model.Manifestation;
+import com.vzome.core.model.Panel;
+import com.vzome.core.model.Strut;
+import java.util.ArrayList;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import org.junit.Test;
+
+/**
+ * @author David Hall
+ */
+public class ManifestationIteratorTest {
+    
+    @Test
+    public void IteratorTest () {
+        Selection selection = new Selection();
+        AlgebraicField field = new PentagonField();
+        int expC = 0, expS = 0, expP = 0;
+        {
+            ArrayList<Manifestation> cList = new ArrayList<>();
+            AlgebraicNumber s = field .createRational( 7 );
+            AlgebraicNumber t = field .createRational( 6 );
+            AlgebraicNumber u = field .createRational( 5 );
+            AlgebraicNumber v = field .createRational( 4 );
+            AlgebraicNumber w = field .createRational( 3 );
+            AlgebraicNumber x = field .createRational( 2 );
+            AlgebraicNumber y = field .createRational( 1 );
+            AlgebraicNumber z = field .createRational( 0 );
+
+            Connector a = new Connector( new AlgebraicVector(w, x, y) );
+            Connector b = new Connector( new AlgebraicVector(z, w, x) );
+            Connector c = new Connector( new AlgebraicVector(y, z, w) );
+            Connector d = new Connector( new AlgebraicVector(x, y, z) );
+
+            Connector e = new Connector( new AlgebraicVector(s, t, u) );
+            Connector f = new Connector( new AlgebraicVector(v, s, t) );
+            Connector g = new Connector( new AlgebraicVector(u, v, s) );
+            Connector h = new Connector( new AlgebraicVector(t, u, v) );
+            Connector i = new Connector( new AlgebraicVector(t, u, u) );
+            cList .add( a );
+            cList .add( b );
+            cList .add( c );
+            cList .add( d );
+            
+            cList .add( e );
+            cList .add( f );
+            cList .add( g );
+            cList .add( h );
+            cList .add( i );
+            
+            a.setHidden(true);
+            e.setHidden(true);
+            i.setHidden(true);
+
+            expC = cList.size();
+            for(Manifestation m : cList) {
+                selection.select(m);
+            }
+        }
+        {
+            ArrayList<Manifestation> sList = new ArrayList<>();
+            ArrayList<Manifestation> pList = new ArrayList<>();
+            ArrayList<AlgebraicVector> avList = new ArrayList<>();
+            
+            AlgebraicNumber s = field.createRational(7);
+            AlgebraicNumber t = field.createRational(6);
+            AlgebraicNumber u = field.createRational(5);
+            AlgebraicNumber v = field.createRational(4);
+            AlgebraicNumber w = field.createRational(3);
+            AlgebraicNumber x = field.createRational(2);
+            AlgebraicNumber ONE = field.createRational(1);
+            AlgebraicNumber ZERO = field.createRational(0);
+
+            AlgebraicVector ORIGIN = new AlgebraicVector(ZERO, ZERO, ZERO);
+            AlgebraicVector PLUS_X = new AlgebraicVector(ONE, ZERO, ZERO);
+            AlgebraicVector PLUS_Y = new AlgebraicVector(ZERO, ONE, ZERO);
+            AlgebraicVector PLUS_Z = new AlgebraicVector(ZERO, ZERO, ONE);
+            
+            AlgebraicVector a = new AlgebraicVector(w, x, ONE);
+            AlgebraicVector b = new AlgebraicVector(ZERO, w, x);
+            AlgebraicVector c = new AlgebraicVector(ONE, ZERO, w);
+            AlgebraicVector d = new AlgebraicVector(x, ONE, ZERO);
+
+            AlgebraicVector e = new AlgebraicVector(s, t, u);
+            AlgebraicVector f = new AlgebraicVector(v, s, t);
+            AlgebraicVector g = new AlgebraicVector(u, v, s);
+            AlgebraicVector h = new AlgebraicVector(t, u, v);
+            AlgebraicVector i = new AlgebraicVector(t, u, u);
+
+            // TODO: Add a test to be sure that clearing the list 
+            // that we passed to the panel c'tor doesn't change 
+            // the panel's internal list and therefore its hashCode.
+            // Also cache panel.toString() on first use.
+            avList.add(ORIGIN);
+            avList.add(PLUS_X);
+            avList.add(PLUS_Y);
+            pList.add( new Panel(avList));
+            avList.clear();
+
+            // TODO: Add a test that a panel with points in reverse order is still equal
+            // and that starting at a different corner is still equal.
+            // and that hashcode is the same when they are equal.
+            // add a note in the Panel hashcode method to point out 
+            // that the hashcode must be the same for all these conditions.
+            // Make the same tests for panel and polyhedron equality.
+            
+            // TODO: Fix Panel so it calculates the normal correctly if the first three points are collinear.
+            // Add a test for that condition.
+            // TODO: Add a test that the normal is negated when the points are reversed.
+            
+            // TODO: Add the new com.vzome.core.model.Manifestation logger level to the sample logging.properties.
+            
+            // TODO: If normal .isOrigin() in Panel or Face.getNormal(), then log an error or throw an exception. 
+            // This would probably only happen in an unknowing test case.
+            
+//            avList.add(ORIGIN);
+//            avList.add(PLUS_Y);
+//            avList.add(PLUS_X);
+//            pList.add( new Panel(avList));
+//            avList.clear();
+
+            avList.add(ORIGIN);
+            avList.add(PLUS_Y);
+            avList.add(PLUS_Z);
+            pList.add( new Panel(avList));
+            avList.clear();
+
+            avList.add(PLUS_Z);
+            avList.add(a);
+            avList.add(b);
+            pList.add( new Panel(avList));
+            avList.clear();
+
+            avList.add(c);
+            avList.add(d);
+            avList.add(e);
+            pList.add( new Panel(avList));
+            avList.clear();
+
+            avList.add(f);
+            avList.add(g);
+            avList.add(h);
+            avList.add(i);
+            pList.add( new Panel(avList));
+            avList.clear();
+            
+            pList.get(0).setHidden(true);
+
+            Strut sa = new Strut(ORIGIN, a);
+            Strut sb = new Strut(ORIGIN, b);
+            Strut sc = new Strut(ORIGIN, c);
+            Strut sd = new Strut(ORIGIN, d);
+
+            Strut se = new Strut(e, ORIGIN);
+            Strut sf = new Strut(f, ORIGIN);
+            Strut sg = new Strut(g, ORIGIN);
+            Strut sh = new Strut(h, ORIGIN);
+            Strut si = new Strut(i, ORIGIN);
+
+            Strut X_AXIS = new Strut(ORIGIN, PLUS_X);
+            Strut Y_AXIS = new Strut(ORIGIN, PLUS_Y);
+            Strut Z_AXIS = new Strut(ORIGIN, PLUS_Z);
+            
+            X_AXIS.setHidden(true);
+            Y_AXIS.setHidden(true);
+            Z_AXIS.setHidden(true);
+
+            sList.add(sa);
+            sList.add(sb);
+            sList.add(sc);
+            sList.add(sd);
+            sList.add(se);
+            sList.add(sf);
+            sList.add(sg);
+            sList.add(sh);
+            sList.add(si);
+            sList.add(X_AXIS);
+            sList.add(Y_AXIS);
+            sList.add(Z_AXIS);
+            
+            for (Manifestation m : sList) {
+                selection.select(m);
+            }
+            expS = sList.size();
+            
+            for (Manifestation m : pList) {
+                selection.select(m);
+            }
+            expP = pList.size();
+        }
+
+        assertTrue(expC > 0);
+        assertTrue(expS > 0);
+        assertTrue(expP > 0);
+        assertTrue(selection.size() > 0);
+        assertEquals(selection.size(), expC + expS + expP);
+
+        int nc = 0;
+        for(Connector connector : Manifestations.Connectors(selection)) {
+            assertEquals("Connectors: ", connector.getClass(), Connector.class);
+            nc++;
+        }
+        assertTrue(expC > 0);
+        assertEquals(expC, nc);
+        
+        int nv = 0;
+        for(Manifestation man : Manifestations.VisibleManifestations(selection)) {
+            nv++;
+        }
+        assertTrue(nv > 0);
+        assertEquals(selection.size() - 7, nv); // we hid 7 of them
+        assertTrue(nv < selection.size());
+        
+        int ns = 0;
+        for(Strut strut : Manifestations.Struts(selection)) {
+            assertEquals("Struts: ", strut.getClass(), Strut.class);
+            ns++;
+        }
+        assertTrue(expS > 0);
+        assertEquals(expS, ns);
+        
+        int np = 0;
+        for(Panel panel : Manifestations.Panels(selection)) {
+            assertEquals("Panels: ", panel.getClass(), Panel.class);
+            np++;
+        }
+        assertTrue(expP > 0);
+        assertEquals(expP, np);
+        
+    }
+
+}

--- a/src/test/java/com/vzome/core/model/PanelTest.java
+++ b/src/test/java/com/vzome/core/model/PanelTest.java
@@ -1,0 +1,93 @@
+package com.vzome.core.model;
+
+import com.vzome.core.algebra.AlgebraicField;
+import com.vzome.core.algebra.AlgebraicNumber;
+import com.vzome.core.algebra.AlgebraicVector;
+import com.vzome.core.algebra.PentagonField;
+import java.util.ArrayList;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import org.junit.Test;
+
+/**
+ * @author David Hall
+ */
+public class PanelTest {
+    
+    @Test
+    public void testVerticesAreInvariant() {
+        AlgebraicField field = new PentagonField();
+        AlgebraicNumber w = field.createRational(0);
+        AlgebraicNumber x = field.createRational(1);
+        AlgebraicNumber y = field.createRational(2);
+        AlgebraicNumber z = field.createRational(3);
+        AlgebraicVector a = new AlgebraicVector(w, x, y);
+        AlgebraicVector b = new AlgebraicVector(z, w, x);
+        AlgebraicVector c = new AlgebraicVector(y, z, w);
+        AlgebraicVector d = new AlgebraicVector(x, y, z);
+
+        ArrayList<AlgebraicVector> list = new ArrayList<>();
+        list.add(a);
+        list.add(b);
+        list.add(c);
+        list.add(d);
+        Panel panel = new Panel(list);
+
+        int expected = list.size();
+        assertTrue(expected >= 3);
+        assertEquals(expected, panel.getVertexCount());
+        // be sure the panel's vertex collection can't be changed after the fact.
+        list.clear();
+        assertEquals(expected, panel.getVertexCount());
+    }
+    
+    @Test
+    public void testNormalsMatchVertexOrder() {
+        AlgebraicField field = new PentagonField();
+        
+        AlgebraicNumber ZERO = field.createRational(0);
+        AlgebraicNumber POS1 = field.createRational(181,3982);
+        AlgebraicNumber POS2 = field.createRational(27);
+        AlgebraicNumber POS3 = field.createRational(3555,78);
+        AlgebraicNumber NEG1 = field.createRational(-175);
+        AlgebraicNumber NEG2 = field.createRational(-2,42345690);
+        AlgebraicNumber NEG3 = field.createRational(-324);
+//        AlgebraicVector p = new AlgebraicVector(POS1, ZERO, ZERO);
+//        AlgebraicVector q = new AlgebraicVector(ZERO, POS1, ZERO);
+//        AlgebraicVector r = new AlgebraicVector(ZERO, ZERO, POS1);
+        AlgebraicVector p = new AlgebraicVector(NEG3, ZERO, POS2);
+        AlgebraicVector q = new AlgebraicVector(ZERO, POS1, POS3);
+        AlgebraicVector r = new AlgebraicVector(NEG1, NEG2, POS1);
+
+        ArrayList<AlgebraicVector> list = new ArrayList<>();
+        list.add(p);
+        list.add(q);
+        list.add(r);
+        Panel p0 = new Panel(list);
+
+        int size = list.size();
+        assertTrue(size >= 3);
+        
+        AlgebraicVector n0 = p0.getNormal();
+        assertFalse(n0.isOrigin());
+        
+//        list.add(1, list.remove(0)); // swap first two
+        list.add(2, list.remove(1)); // swap last two
+        
+        Panel p1 = new Panel(list);
+        assertEquals(size, list.size());
+        
+        AlgebraicVector n1 = p1.getNormal();
+        assertFalse(n1.isOrigin());
+        
+        // normals should be equal but opposite directions.
+        // so adding them should equal zero
+        AlgebraicVector sum = n0.plus(n1);
+        assertTrue(sum.isOrigin());
+        
+        // TODO: Make a specific panel with a known normal and be sure the direction is as expected for the right hand rule 
+        //  or at leaast backward compatible with earlier versions...
+    }
+    
+}


### PR DESCRIPTION
Hi Scott,
Finally finished up these 3 new selection commands. I've had them working fro several weeks but hadn't tested that they are saved to a file and read back correctly. I did all of that testing tonight so it's all ready for you to pull in if you like them. I'll send a corresponding pull request for vzome-desktop which add the new commands to the main menu and to the strut context menu.

I've also got all of the color mapping working but I still have to test that it saves and reads back from a file correctly. I'll push that too once it's fully tested.

Here's what's changed in this commit:
* Bumped version number to 0.8.4
* New Select Parallel, Collinear or Automatic strut commands.
* Clarify a few error messages.
* Add new FilteredIterator and SubClassIterator classes.
* Add getNormal and areCollinear static AlgebraicVector methods
* Copy vertices in Panel c'tor so caller can't change them later.
* Remove unused Axis.Logger.
* Enable more verbose compiler warnings
* Add more tests for Panel