### PR TITLE
0.8.4 has 3 new Strut selection commands

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'eclipse'
 //apply plugin: 'antlr4'
 
 group = 'com.vzome.core'
-version = '0.8.3'
+version = '0.8.4'
 
 description = "vzome-core"
 
@@ -74,6 +74,7 @@ dependencies {
 gradle.projectsEvaluated {
 	tasks.withType(JavaCompile) {
 		options.compilerArgs \
+		<< "-Xdiags:verbose" \
 		<< "-Xlint:all" \
 		<< "-Xlint:cast" \
 		<< "-Xlint:divzero" \

--- a/src/main/java/com/vzome/core/algebra/AlgebraicVector.java
+++ b/src/main/java/com/vzome/core/algebra/AlgebraicVector.java
@@ -98,13 +98,21 @@ public final class AlgebraicVector implements Comparable<AlgebraicVector>
     }
 
     /**
-     * @return Returns a String with no extended characters so it's suitable for writing 
+     * @return A String with no extended characters so it's suitable for writing
      * to an 8 bit stream such as System.out or an ASCII text log file in Windows.
      * Contrast this with {@link toString()} which contains extended characters (e.g. \u03C4 (phi))
      */
     public final String toASCIIString()
     {
         return this .getVectorExpression( AlgebraicField .EXPRESSION_FORMAT );
+    }
+
+    /**
+     * @return A String representation that can be persisted to XML and parsed by XmlSaveFormat.parseRationalVector().
+     */
+    public final String toParsableString()
+    {
+        return this .getVectorExpression( AlgebraicField .ZOMIC_FORMAT );
     }
 
     @Override
@@ -251,6 +259,14 @@ public final class AlgebraicVector implements Comparable<AlgebraicVector>
             return this .coordinates[ i ] .dividedBy( unit .coordinates[ i ] );
         }
         throw new IllegalStateException( "vector is the origin!" );
+    }
+    
+    public static AlgebraicVector getNormal(final AlgebraicVector v0, final AlgebraicVector v1, final AlgebraicVector v2) {
+        return v1.minus(v0).cross(v2.minus(v0));
+    }
+
+    public static boolean areCollinear(final AlgebraicVector v0, final AlgebraicVector v1, final AlgebraicVector v2) {
+        return getNormal(v0, v1, v2).isOrigin();
     }
 
     public AlgebraicField getField()

--- a/src/main/java/com/vzome/core/editor/ChangeManifestations.java
+++ b/src/main/java/com/vzome/core/editor/ChangeManifestations.java
@@ -11,22 +11,31 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import com.vzome.core.construction.Construction;
+import com.vzome.core.model.Connector;
 import com.vzome.core.model.Manifestation;
+import com.vzome.core.model.Panel;
 import com.vzome.core.model.RealizedModel;
+import com.vzome.core.model.Strut;
+import java.util.function.Predicate;
 
 public abstract class ChangeManifestations extends ChangeSelection
 {
     protected final RealizedModel mManifestations;
     
+    public ChangeManifestations( Selection selection, RealizedModel realized )
+    {
+        this( selection, realized, false);
+    }
+    
     public ChangeManifestations( Selection selection, RealizedModel realized, boolean groupInSelection )
     {
         super( selection, groupInSelection );
-        
+
         mManifestations = realized;
         // TODO: DJH: Can this be replaced by a HashSet since the key is always equal to the value.
         mManifestedNow = new HashMap<>();
     }
-    
+
     /**
      * This records the NEW manifestations produced by manifestConstruction for this edit,
      * to avoid creating colliding manifestations.  It is never referenced after the last
@@ -254,5 +263,46 @@ public abstract class ChangeManifestations extends ChangeSelection
         {
         	return this .mShowing && this .mManifestation .equals( man );
         }
+
     }
+
+
+    // Commonly used Filtered Iterators
+
+    protected Manifestations.ConnectorIterator getConnectors() {
+        return Manifestations.getConnectors(mManifestations);
+    }
+
+    protected Manifestations.StrutIterator getStruts() {
+        return Manifestations.getStruts(mManifestations);
+    }
+
+    protected Manifestations.PanelIterator getPanels() {
+        return Manifestations.getPanels(mManifestations);
+    }
+
+    protected Manifestations.ConnectorIterator getVisibleConnectors() {
+        return Manifestations.getVisibleConnectors(mManifestations);
+    }
+
+    protected Manifestations.StrutIterator getVisibleStruts() {
+        return Manifestations.getVisibleStruts(mManifestations);
+    }
+
+    protected Manifestations.PanelIterator getVisiblePanels() {
+        return Manifestations.getVisiblePanels(mManifestations);
+    }
+
+    protected Manifestations.ConnectorIterator getVisibleConnectors(Predicate<Connector> postFilter) {
+        return Manifestations.getVisibleConnectors(mManifestations, postFilter);
+    }
+
+    protected Manifestations.StrutIterator getVisibleStruts(Predicate<Strut> postFilter) {
+        return Manifestations.getVisibleStruts(mManifestations, postFilter);
+    }
+
+    protected Manifestations.PanelIterator getVisiblePanels(Predicate<Panel> postFilter) {
+        return Manifestations.getVisiblePanels(mManifestations, postFilter);
+    }
+
 }

--- a/src/main/java/com/vzome/core/editor/ChangeSelection.java
+++ b/src/main/java/com/vzome/core/editor/ChangeSelection.java
@@ -11,9 +11,12 @@ import org.w3c.dom.Element;
 import com.vzome.core.commands.XmlSaveFormat;
 import com.vzome.core.commands.Command.Failure;
 import com.vzome.core.math.DomUtils;
+import com.vzome.core.model.Connector;
 import com.vzome.core.model.Group;
 import com.vzome.core.model.GroupElement;
 import com.vzome.core.model.Manifestation;
+import com.vzome.core.model.Panel;
+import com.vzome.core.model.Strut;
 
 public abstract class ChangeSelection extends SideEffects
 {
@@ -23,14 +26,19 @@ public abstract class ChangeSelection extends SideEffects
     
     private boolean groupingDoneInSelection;
 
-    private static final Logger logger = Logger.getLogger( "com.vzome.core.editor.ChangeSelection" );
+    protected static final Logger logger = Logger.getLogger( "com.vzome.core.editor.ChangeSelection" );
+
+    ChangeSelection( Selection selection )
+    {
+        this(selection, false);
+    }
 
     ChangeSelection( Selection selection, boolean groupInSelection )
     {
         mSelection = selection;
         groupingDoneInSelection = groupInSelection;
     }
-    
+
     protected void getXmlAttributes( Element element ) {}
     
     protected void setXmlAttributes( Element xml, XmlSaveFormat format ) throws Failure {}
@@ -224,4 +232,109 @@ public abstract class ChangeSelection extends SideEffects
             return result;
         }
     }
+
+    ////////////////////////
+    /// getSelected...
+    ////////////////////////
+
+    protected Manifestations.ConnectorIterator getSelectedConnectors() {
+        return Manifestations.getConnectors(mSelection);
+    }
+
+    protected Manifestations.StrutIterator getSelectedStruts() {
+        return Manifestations.getStruts(mSelection);
+    }
+
+    protected Manifestations.PanelIterator getSelectedPanels() {
+        return Manifestations.getPanels(mSelection);
+    }
+
+    ////////////////////////
+    /// getLastSelected...
+    ////////////////////////
+
+    public Manifestation getLastSelectedManifestation() {
+        Manifestation last = null;
+        for( Manifestation man : mSelection ) {
+            last = man;
+        }
+        return last;
+    }
+
+    public Connector getLastSelectedConnector() {
+        Connector last = null;
+        for( Connector connector : getSelectedConnectors() ) {
+            last = connector;
+        }
+        return last;
+    }
+
+    public Strut getLastSelectedStrut() {
+        Strut last = null;
+        for( Strut strut : getSelectedStruts() ) {
+            last = strut;
+        }
+        return last;
+    }
+
+    public Panel getLastSelectedPanel() {
+        Panel last = null;
+        for( Panel panel : getSelectedPanels() ) {
+            last = panel;
+        }
+        return last;
+    }
+
+    ////////////////////////
+    // unselect...
+    ////////////////////////
+
+    public boolean unselectAll() {
+        boolean anySelected = false;
+        for( Manifestation man : mSelection ) {
+            anySelected = true;
+            this.unselect(man);
+        }
+        if(anySelected) {
+            redo();
+        }
+        return anySelected;
+    }
+
+    public boolean unselectConnectors() {
+        boolean anySelected = false;
+        for( Connector connector : getSelectedConnectors() ) {
+            anySelected = true;
+            this.unselect(connector);
+        }
+        if(anySelected) {
+            redo();
+        }
+        return anySelected;
+    }
+
+    public boolean unselectStruts() {
+        boolean anySelected = false;
+        for( Strut strut : getSelectedStruts() ) {
+            anySelected = true;
+            this.unselect(strut);
+        }
+        if(anySelected) {
+            redo();
+        }
+        return anySelected;
+    }
+
+    public boolean unselectPanels() {
+        boolean anySelected = false;
+        for( Panel panel : getSelectedPanels() ) {
+            anySelected = true;
+            this.unselect(panel);
+        }
+        if(anySelected) {
+            redo();
+        }
+        return anySelected;
+    }
+
 }

--- a/src/main/java/com/vzome/core/editor/DocumentModel.java
+++ b/src/main/java/com/vzome/core/editor/DocumentModel.java
@@ -359,16 +359,25 @@ public class DocumentModel implements Snapshot .Recorder, UndoableEdit .Context,
 
 		else if ( "SelectSimilarSize".equals( name ) )
 		{
+            /*
+            The normal pattern is to have the edits deserialize their own parameters from the XML in setXmlAttributes()
+            but in the case of persisting the symmetry, it must be read here and passed into the c'tor
+            since this is where the map from a name to an actual SymmetrySystem is maintained.
+            These edits are still responsible for saving the symmetry name to XML in getXmlAttributes().
+            Also see the comments of commit # 8c8cb08a1e4d71f91f24669b203fef0378230b19 on 3/8/2015
+            */
 		    SymmetrySystem symmetry = this .symmetrySystems .get( xml .getAttribute( "symmetry" ) );
             edit = new SelectSimilarSizeStruts( symmetry, null, null, this .mSelection, this .mRealizedModel );
 		}
 		else if ( "SelectParallelStruts".equals( name ) )
 		{
+            // See the note above about deserializing symmetry from XML.
 		    SymmetrySystem symmetry = this .symmetrySystems .get( xml .getAttribute( "symmetry" ) );
             edit = new SelectParallelStruts( symmetry, this .mSelection, this .mRealizedModel );
 		}
 		else if ( "SelectAutomaticStruts".equals( name ) )
 		{
+            // See the note above about deserializing symmetry from XML.
 		    SymmetrySystem symmetry = this .symmetrySystems .get( xml .getAttribute( "symmetry" ) );
             edit = new SelectAutomaticStruts( symmetry, this .mSelection, this .mRealizedModel );
 		}

--- a/src/main/java/com/vzome/core/editor/EditorModel.java
+++ b/src/main/java/com/vzome/core/editor/EditorModel.java
@@ -98,13 +98,27 @@ public class EditorModel
             return new NoOp();
     }
 
+    public UndoableEdit selectAutomaticStruts(SymmetrySystem symmetry)
+    {
+        return new SelectAutomaticStruts(symmetry, mSelection, mRealized );
+    }
+
+    public UndoableEdit selectCollinear()
+    {
+        return new SelectCollinear(mSelection, mRealized );
+    }
+
+	public UndoableEdit selectParallelStruts(SymmetrySystem symmetry) {
+		return new SelectParallelStruts(symmetry, mSelection, mRealized);
+	}
+
     public UndoableEdit invertSelection()
     {
         return new InvertSelection( mSelection, mRealized, false );
         // always a change, by definition
     }
     
-    private RealizedModel mRealized;
+    private final RealizedModel mRealized;
 
     protected Selection mSelection;
     

--- a/src/main/java/com/vzome/core/editor/Manifestations.java
+++ b/src/main/java/com/vzome/core/editor/Manifestations.java
@@ -1,0 +1,138 @@
+package com.vzome.core.editor;
+
+import com.vzome.core.generic.SubClassIterator;
+import com.vzome.core.generic.FilteredIterator;
+import com.vzome.core.model.Connector;
+import com.vzome.core.model.Manifestation;
+import com.vzome.core.model.Panel;
+import com.vzome.core.model.Strut;
+import com.vzome.core.render.RenderedManifestation;
+import java.util.function.Predicate;
+
+/**
+ * @author David Hall
+ */
+public class Manifestations {
+    
+    // Manifestations
+    public static ManifestationIterator visibleManifestations(Iterable<Manifestation> manifestations) {
+        return new ManifestationIterator(Filters::isVisible, manifestations, null);
+    }
+    public static ManifestationIterator visibleManifestations(Predicate<Manifestation> preTest, Iterable<Manifestation> manifestations) {
+        return new ManifestationIterator(preTest, manifestations, Filters::isVisible);
+    }
+    public static ManifestationIterator visibleManifestations(Iterable<Manifestation> manifestations, Predicate<Manifestation> postTest) {
+        return new ManifestationIterator(Filters::isVisible, manifestations, postTest);
+    }
+    public static class ManifestationIterator extends FilteredIterator<Manifestation, Manifestation> {
+        public ManifestationIterator(Predicate<Manifestation> preTest, Iterable<Manifestation> manifestations, Predicate<Manifestation> postTest) {
+            super(preTest, manifestations, postTest);
+        }
+        @Override
+        protected Manifestation apply(Manifestation element) {
+            return element;
+        }
+    }
+    
+    // RenderedManifestations
+    public static RenderedManifestationIterator getRenderedManifestations(Iterable<Manifestation> manifestations) {
+        // Either this preTest or this postTest would do the job in this case.
+        // Using both doesn't help or hurt. It just documents the options.
+        return new RenderedManifestationIterator(Filters::isRendered, manifestations, FilteredIterator.Filters::resultNotNull);
+    }
+    public static RenderedManifestationIterator getRenderedManifestations(Predicate<Manifestation> preTest, Iterable<Manifestation> manifestations) {
+        return new RenderedManifestationIterator(preTest, manifestations, FilteredIterator.Filters::resultNotNull);
+    }
+    public static RenderedManifestationIterator getRenderedManifestations(Iterable<Manifestation> manifestations, Predicate<RenderedManifestation> postTest) {
+        return new RenderedManifestationIterator(Filters::isRendered, manifestations, postTest);
+    }
+    public static class RenderedManifestationIterator extends FilteredIterator<Manifestation, RenderedManifestation> {
+        public RenderedManifestationIterator(Predicate<Manifestation> preTest, Iterable<Manifestation> manifestations, Predicate<RenderedManifestation> postTest) {
+            super(preTest, manifestations, postTest);
+        }
+        @Override
+        protected RenderedManifestation apply(Manifestation element) {
+            return element.getRenderedObject();
+        }
+    }
+
+    // Connectors        
+    public static ConnectorIterator getConnectors(Iterable<Manifestation> manifestations) {
+        return new ConnectorIterator(null, manifestations, null);
+    }
+    public static ConnectorIterator getConnectors(Iterable<Manifestation> manifestations, Predicate<Connector> postFilter) {
+        return new ConnectorIterator(null, manifestations, postFilter);
+    }
+    public static ConnectorIterator getConnectors(Predicate<Manifestation> preFilter, Iterable<Manifestation> manifestations, Predicate<Connector> postFilter) {
+        return new ConnectorIterator(preFilter, manifestations, postFilter);
+    }
+    public static ConnectorIterator getVisibleConnectors(Iterable<Manifestation> manifestations) {
+        return getVisibleConnectors(manifestations, null);
+    }
+    public static ConnectorIterator getVisibleConnectors(Iterable<Manifestation> manifestations, Predicate<Connector> postFilter) {
+        return new ConnectorIterator(Filters::isVisible, manifestations, postFilter);
+    }
+    public static class ConnectorIterator extends SubClassIterator<Manifestation, Connector> {
+        private ConnectorIterator(Predicate<Manifestation> preFilter, Iterable<Manifestation> manifestations, Predicate<Connector> postFilter) {
+            super(Connector.class, preFilter, manifestations, postFilter);
+        }
+    }
+
+    // Struts
+    public static StrutIterator getStruts(Iterable<Manifestation> manifestations) {
+        return new StrutIterator(null, manifestations, null);
+    }
+    public static StrutIterator getStruts(Iterable<Manifestation> manifestations, Predicate<Strut> postFilter) {
+        return new StrutIterator(null, manifestations, postFilter);
+    }
+    public static StrutIterator getStruts(Predicate<Manifestation> preFilter, Iterable<Manifestation> manifestations, Predicate<Strut> postFilter) {
+        return new StrutIterator(preFilter, manifestations, postFilter);
+    }
+    public static StrutIterator getVisibleStruts(Iterable<Manifestation> manifestations) {
+        return getVisibleStruts(manifestations, null);
+    }
+    public static StrutIterator getVisibleStruts(Iterable<Manifestation> manifestations, Predicate<Strut> postFilter) {
+        return new StrutIterator(Filters::isVisible, manifestations, postFilter);
+    }
+    public static class StrutIterator extends SubClassIterator<Manifestation, Strut> {
+        private StrutIterator(Predicate<Manifestation> preFilter, Iterable<Manifestation> manifestations, Predicate<Strut> postFilter) {
+            super(Strut.class, preFilter, manifestations, postFilter);
+        }
+    }
+
+    // Panels
+    public static PanelIterator getPanels(Iterable<Manifestation> manifestations) {
+        return new PanelIterator(null, manifestations, null);
+    }
+    public static PanelIterator getPanels(Iterable<Manifestation> manifestations, Predicate<Panel> postFilter) {
+        return new PanelIterator(null, manifestations, postFilter);
+    }
+    public static PanelIterator getPanels(Predicate<Manifestation> preFilter, Iterable<Manifestation> manifestations, Predicate<Panel> postFilter) {
+        return new PanelIterator(preFilter, manifestations, postFilter);
+    }
+    public static PanelIterator getVisiblePanels(Iterable<Manifestation> manifestations) {
+        return getVisiblePanels(manifestations, null);
+    }
+    public static PanelIterator getVisiblePanels(Iterable<Manifestation> manifestations, Predicate<Panel> postFilter) {
+        return new PanelIterator(Filters::isVisible, manifestations, postFilter);
+    }
+    public static class PanelIterator extends SubClassIterator<Manifestation, Panel> {
+        private PanelIterator(Predicate<Manifestation> preFilter, Iterable<Manifestation> manifestations, Predicate<Panel> postFilter) {
+            super(Panel.class, preFilter, manifestations, postFilter);
+        }
+    }
+
+    public static class Filters {
+        private Filters() {}; // no public c'tor
+
+        public static boolean isRendered(Manifestation man) {
+            return man.isRendered();
+        }
+
+        public static boolean isVisible(Manifestation man) {
+            return !man.isHidden();
+        }
+
+
+    }
+}

--- a/src/main/java/com/vzome/core/editor/SelectAutomaticStruts.java
+++ b/src/main/java/com/vzome/core/editor/SelectAutomaticStruts.java
@@ -1,6 +1,7 @@
 package com.vzome.core.editor;
 
 import com.vzome.core.commands.Command.Failure;
+import com.vzome.core.commands.XmlSaveFormat;
 import com.vzome.core.math.DomUtils;
 import com.vzome.core.model.RealizedModel;
 import com.vzome.core.model.Strut;
@@ -17,7 +18,8 @@ public class SelectAutomaticStruts extends ChangeManifestations {
 		super(selection, model);
 		this.symmetry = symm;
 	}
-	
+
+    // See the note in SelectSimilarSizeStruts regarding different symmetries. The same logic applies here.
 	@Override
 	public void perform() throws Failure {
         unselectAll();
@@ -41,5 +43,16 @@ public class SelectAutomaticStruts extends ChangeManifestations {
         if (symmetry != null) {
             DomUtils.addAttribute(element, "symmetry", symmetry.getName());
         }
+    }
+
+    // Note that symmetry is read from the XML and passed to the c'tor
+    // unlike the normal pattern of deserializing the XML here.
+    // See the explanation in DocumentModel.createEdit()
+    // There's really no need to override setXmlAttributes in this case
+    // since there is nothing else to deserialize. but it does serve as a reminder
+    // if this code is used as a pattern for another subclass of ChangeSelection.
+    @Override
+    protected void setXmlAttributes(Element xml, XmlSaveFormat format)
+            throws Failure {
     }
 }

--- a/src/main/java/com/vzome/core/editor/SelectAutomaticStruts.java
+++ b/src/main/java/com/vzome/core/editor/SelectAutomaticStruts.java
@@ -1,0 +1,45 @@
+package com.vzome.core.editor;
+
+import com.vzome.core.commands.Command.Failure;
+import com.vzome.core.math.DomUtils;
+import com.vzome.core.model.RealizedModel;
+import com.vzome.core.model.Strut;
+import org.w3c.dom.Element;
+
+/**
+ * @author David Hall
+ */
+public class SelectAutomaticStruts extends ChangeManifestations {
+
+	protected final SymmetrySystem symmetry;
+	
+	public SelectAutomaticStruts(SymmetrySystem symm, Selection selection, RealizedModel model) {
+		super(selection, model);
+		this.symmetry = symm;
+	}
+	
+	@Override
+	public void perform() throws Failure {
+        unselectAll();
+        for( Strut strut : getVisibleStruts(this::isAutomaticStrut) ) {
+            select(strut);
+		}
+		super.perform();
+	}
+	
+    private boolean isAutomaticStrut(Strut strut) {
+        return symmetry.getAxis(strut.getOffset()).getOrbit().isAutomatic();
+    }
+    
+	@Override
+	protected String getXmlElementName() {
+		return "SelectAutomaticStruts";
+	}
+
+    @Override
+    protected void getXmlAttributes(Element element) {
+        if (symmetry != null) {
+            DomUtils.addAttribute(element, "symmetry", symmetry.getName());
+        }
+    }
+}

--- a/src/main/java/com/vzome/core/editor/SelectCollinear.java
+++ b/src/main/java/com/vzome/core/editor/SelectCollinear.java
@@ -1,0 +1,149 @@
+package com.vzome.core.editor;
+
+import com.vzome.core.algebra.AlgebraicVector;
+import com.vzome.core.commands.Command;
+import com.vzome.core.commands.Command.Failure;
+import com.vzome.core.commands.XmlSaveFormat;
+import static com.vzome.core.editor.ChangeSelection.logger;
+import com.vzome.core.math.DomUtils;
+import com.vzome.core.model.Connector;
+import com.vzome.core.model.RealizedModel;
+import com.vzome.core.model.Strut;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.logging.Level;
+import org.w3c.dom.Element;
+
+/**
+ * @author David Hall
+ */
+public class SelectCollinear extends ChangeManifestations {
+
+    private AlgebraicVector vector1;
+    private AlgebraicVector vector2;
+    private boolean vectorsFromSelection = false;
+
+	/**
+	* Called by the context menu. Input is the strut associated with the context menu.
+	*/
+    public SelectCollinear(Selection selection, RealizedModel model, Strut strut) {
+        super(selection, model);
+        this.vector1 = strut.getLocation();
+        this.vector2 = strut.getEnd();
+        vectorsFromSelection = false;
+    }
+
+	/**
+	* Called by the main menu and when opening a file.
+    * Input is either the last selected strut if present, or else the last two selected balls.
+	*/
+    public SelectCollinear(Selection selection, RealizedModel model) {
+        super(selection, model);
+        AlgebraicVector v1 = null;
+        AlgebraicVector v2 = null;
+        Strut lastStrut = null;
+        for (Strut strut : getSelectedStruts()) {
+            lastStrut = strut;
+        }
+        if (lastStrut != null) {
+            v1 = lastStrut.getLocation();
+            v2 = lastStrut.getEnd();
+        } else {
+            for (Connector ball : getSelectedConnectors()) {
+                // use the last two balls selected if a strut was not selected
+                v1 = v2;
+                v2 = ball.getLocation();
+            }
+        }
+        vector1 = v1;
+        vector2 = v2;
+        vectorsFromSelection = (vector1 != null && vector2 != null);
+    }
+
+    @Override
+    public void perform() throws Command.Failure {
+        if (vector1 == null || vector2 == null) {
+            throw new Failure("select a strut or two balls as a reference.");
+        }
+        unselectAll();
+
+        Set<Connector> balls = new TreeSet<>(); // auto sorted
+        // Example of using FilteredIterator with Predicate parameter.
+        for (Connector ball : getVisibleConnectors(this::isCollinearWith)) {
+            balls.add(ball);
+        }
+
+        Set<Strut> struts = new TreeSet<>(); // auto sorted
+        // Example of conventional "if" syntax within the loop.
+        // Compare to the equivalent FilteredIterator predicate syntax above.
+        for (Strut strut : getVisibleStruts()) {
+            if (isCollinearWith(strut)) {
+                struts.add(strut);
+            }
+        }
+
+        // balls and struts to be selected are now in two sorted sets
+        // so we can select them in a consistent canonical order, suitable
+        // for subsequent use by other tools such as JoinPoints
+        for (Strut strut : struts) {
+            select(strut);
+        }
+        for (Connector ball : balls) {
+            select(ball);
+        }
+
+        Level level = Level.FINER;
+        if (logger.isLoggable(level)) {
+            StringBuilder sb = new StringBuilder("Selected:\n");
+            final String indent = "  ";
+            for (Strut strut : struts) {
+                sb.append(indent).append(strut.toString()).append("\n");
+            }
+            for (Connector ball : balls) {
+                sb.append(indent).append(ball.toString()).append("\n");
+            }
+            logger.log(level, sb.toString());
+        }
+
+        super.perform();
+    }
+
+    private boolean isCollinearWith(Connector ball) {
+        return isCollinear(ball.getLocation());
+    }
+
+    private boolean isCollinearWith(Strut strut) {
+        return isCollinear(strut.getLocation())
+                && isCollinear(strut.getEnd());
+    }
+
+    private boolean isCollinear(AlgebraicVector vec) {
+        return AlgebraicVector.areCollinear(vec, vector1, vector2);
+    }
+
+    @Override
+    protected String getXmlElementName() {
+        return "SelectCollinear";
+    }
+
+    private static final String strVectorsFromSelectionATTR = "vectorsFromSelection";
+
+    @Override
+    protected void getXmlAttributes(Element element) {
+        DomUtils.addAttribute(element, strVectorsFromSelectionATTR, Boolean.toString(vectorsFromSelection));
+        if( !vectorsFromSelection ) {
+            // don't persist the vectors if they are derived from the selection
+            DomUtils.addAttribute(element, "vector1", vector1.toParsableString());
+            DomUtils.addAttribute(element, "vector2", vector2.toParsableString());
+        }
+    }
+
+    @Override
+    protected void setXmlAttributes(Element xml, XmlSaveFormat format) throws Failure {
+        vectorsFromSelection = Boolean.parseBoolean(xml.getAttribute(strVectorsFromSelectionATTR));
+        if(!vectorsFromSelection) {
+            this.vector1 = format.parseRationalVector(xml, "vector1");
+            this.vector2 = format.parseRationalVector(xml, "vector2");
+        }
+    }
+}

--- a/src/main/java/com/vzome/core/editor/SelectParallelStruts.java
+++ b/src/main/java/com/vzome/core/editor/SelectParallelStruts.java
@@ -1,0 +1,120 @@
+package com.vzome.core.editor;
+
+import com.vzome.core.algebra.AlgebraicVector;
+import com.vzome.core.commands.Command.Failure;
+import com.vzome.core.commands.XmlSaveFormat;
+import com.vzome.core.math.DomUtils;
+import com.vzome.core.math.symmetry.Axis;
+import com.vzome.core.math.symmetry.Direction;
+import com.vzome.core.math.symmetry.Symmetry;
+import com.vzome.core.model.RealizedModel;
+import com.vzome.core.model.Strut;
+import org.w3c.dom.Element;
+
+/**
+ * @author David Hall
+ */
+public class SelectParallelStruts extends ChangeManifestations
+{
+    private final SymmetrySystem symmetry;
+    private Direction orbit;
+    private Axis axis;
+
+    /**
+     * called from the main menu and when opening a file
+     * @param symmetry
+     * @param selection
+     * @param model
+     */
+    public SelectParallelStruts(SymmetrySystem symmetry, Selection selection, RealizedModel model)
+    {
+        super( selection, model );
+        this.symmetry = symmetry;
+        Strut lastStrut = getLastSelectedStrut();
+        if (lastStrut != null) {
+            AlgebraicVector offset = lastStrut.getOffset();
+            this.orbit = symmetry.getAxis(offset).getOrbit();
+            this.axis = orbit.getAxis(offset);
+        } else {
+            this.orbit = null;
+            this.axis = null;
+        }
+    }
+
+    /**
+     * called from the strut context menu
+     * @param symmetry
+     * @param selection
+     * @param model
+     * @param strut
+     */
+    public SelectParallelStruts(SymmetrySystem symmetry, Selection selection, RealizedModel model, Strut strut) {
+        super( selection, model );
+        this.symmetry = symmetry;
+        this.axis = symmetry.getAxis( strut .getOffset() );
+        this.orbit = this.axis .getOrbit();
+    }
+
+	// Normal usage cases include invocation from:
+    // 1) Main menu with 1 or more struts selected (Last selected strut will be used as input)
+    // 2) Strut context menu
+    // 3) Undo and Redo operations
+    // 4) Reopening a saved vZome file (persisted as XML)
+    //
+    // Ensure that we can safely do nothing (with no exceptions thrown) when invoked from:
+    // 1) Main menu with nothing selected
+    // 2) Main menu with balls and/or panels selected but no strut selected
+    @Override
+    public void perform() throws Failure {
+        if (orbit == null || axis == null) {
+            throw new Failure("select a reference strut.");
+        }
+        unselectAll();
+
+        int opposite = ( axis .getSense() + 1 ) % 2;
+        Axis oppositeAxis = orbit. getAxis( opposite, axis .getOrientation() );
+
+        for (Strut strut : getStruts()) {
+            Axis strutAxis = symmetry.getAxis(strut .getOffset());
+            if (strutAxis != null && strutAxis.getOrbit().equals(orbit)) {
+                if ( strutAxis.equals(axis) || strutAxis.equals(oppositeAxis) ) {
+                    select(strut);
+                }
+            }
+        }
+        super .perform();
+    }
+
+    @Override
+    protected String getXmlElementName()
+    {
+        return "SelectParallelStruts";
+    }
+
+    @Override
+    protected void getXmlAttributes( Element element )
+    {
+        if ( symmetry != null )
+            DomUtils .addAttribute( element, "symmetry", symmetry .getName() );
+        if ( orbit != null )
+            DomUtils .addAttribute( element, "orbit", orbit .getName() );
+        if ( axis != null )
+            axis.getXML(element);
+    }
+
+    @Override
+    protected void setXmlAttributes( Element xml, XmlSaveFormat format )
+            throws Failure
+    {
+        orbit = symmetry .getOrbits() .getDirection( xml .getAttribute( "orbit" ) );
+        if(orbit == null) {
+            throw new Failure("Can't read orbit from xml.");
+        }
+        String strSense = xml.getAttribute("sense");
+        int sense = (strSense != null && "minus".equals(strSense.toLowerCase()))
+                ? Symmetry.MINUS
+                : Symmetry.PLUS;
+        int index = Integer.parseInt(xml.getAttribute("index"));
+        this.axis = orbit.getAxis(sense, index);
+    }
+}

--- a/src/main/java/com/vzome/core/editor/SelectSimilarSizeStruts.java
+++ b/src/main/java/com/vzome/core/editor/SelectSimilarSizeStruts.java
@@ -21,8 +21,8 @@ public class SelectSimilarSizeStruts extends ChangeSelection
 {
     private Direction orbit;
     private AlgebraicNumber length;
-    private RealizedModel model;
-    private SymmetrySystem symmetry;
+    private final RealizedModel model;
+    private final SymmetrySystem symmetry;
 
     public SelectSimilarSizeStruts( SymmetrySystem symmetry, Direction orbit, AlgebraicNumber length,
             Selection selection, RealizedModel model )
@@ -34,6 +34,17 @@ public class SelectSimilarSizeStruts extends ChangeSelection
         this .length = length;
     }
 
+    /*
+    Although this class is named SelectSimilarSizeStruts, it does not do exactly what its name implies.
+    Specifically, it will only select struts of the same length AND ORBIT within the given symmetry.
+    For example, if short blue struts radiate from the origin with icoshedral symmetry,
+    then we switch to octahedral symmetry, some of the struts will then be on black axes
+    according to the octahedral symmetry system. In that case, when one of the blue struts are selected
+    as the reference for this command, only blue struts of the same length will be selected.
+    None of the black struts will be selected even though they are the same length,
+    since the black struts are no longer in a blue orbit.
+    This behavior is intentional. The struts to be selected are dependent on the selected symmetry.
+    */
     @Override
     public void perform() throws Failure
     {

--- a/src/main/java/com/vzome/core/generic/FilteredIterator.java
+++ b/src/main/java/com/vzome/core/generic/FilteredIterator.java
@@ -1,0 +1,185 @@
+package com.vzome.core.generic;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.function.Predicate;
+
+/**
+ * @author David Hall
+ * Based on http://stackoverflow.com/questions/5474893/how-to-implement-this-filteringiterator
+ */
+public abstract class FilteredIterator<T, R> implements Iterator<R>, Iterable<R> {
+
+    private final Iterator<T> wrappedIterator;
+    private final Predicate<T> preFilter;
+    private final Predicate<R> postFilter;
+    private R nextElement = null;
+    private Boolean hasNext = null; // determined on first use
+
+    /**
+     * Elements must match this filter before conversion
+     * @param element
+     */
+    protected boolean preFilter(T element) {
+        return preFilter == null 
+                ? true
+                : preFilter.test(element);
+    }
+
+    /**
+     * Elements must match this filter after conversion
+     * @param element
+     */
+    protected boolean postFilter(R element) {
+        return postFilter == null 
+                ? true
+                : postFilter.test(element);
+    }
+    
+    /**
+     * Elements are converted from T to R. 
+     * T and R may be identical, related (e.g. sub-classed) or completely unrelated.
+     * @param element
+     */
+    protected abstract R apply(T element);
+
+    protected FilteredIterator(Iterable<T> iterable) {
+        this(null, iterable, null);    
+    }
+
+    protected FilteredIterator(Predicate<T> preTest, Iterable<T> iterable) {
+        this(preTest, iterable, null);    
+    }
+
+    protected FilteredIterator(Iterable<T> iterable, Predicate<R> postTest) {
+        this(null, iterable, postTest);    
+    }
+
+    /**
+     * Creates a new FilteredIterator by wrapping the iterator 
+     *  and returning only converted elements matching the filters.
+     * 
+     * @param preTest may be null to skip preTest;
+     * @param iterable
+     * @param postTest may be null to skip postTest;
+     */
+    protected FilteredIterator(Predicate<T> preTest, Iterable<T> iterable, Predicate<R> postTest) {
+        this.wrappedIterator = iterable.iterator();
+        preFilter = preTest;
+        postFilter = postTest;
+        // can't call nextMatch in any c'tor, because derived classes 
+        // may not be fully initialized yet and their filters may not work.this(preTest, iterable.iterator(), postTest);    
+    }
+
+    @Override
+    public Iterator<R> iterator() {
+        return this; // careful, don't return wrappedIterator
+    }
+
+    @Override
+    public boolean hasNext() {
+        if(hasNext == null) {
+            // first call after c'tor
+            nextMatch();
+        }
+        return hasNext;
+    }
+
+    @Override
+    public R next() {
+        if(hasNext == null) {
+            // first call after c'tor
+            nextMatch();
+        }
+        if (!hasNext) {
+            throw new NoSuchElementException();
+        }
+        return nextMatch();
+    }
+    
+    private R nextMatch() {
+        R lastMatch = nextElement;
+        while (wrappedIterator.hasNext()) {
+            T next = wrappedIterator.next();
+            if (preFilter(next)) {
+                R converted = apply(next);
+                if(postFilter(converted)) {
+                    nextElement = converted;
+                    hasNext = true;
+                    return lastMatch;
+                }
+            }
+        }
+        hasNext = false;
+        return lastMatch;
+    }
+    
+    @Override
+    public void remove() {
+        wrappedIterator.remove();
+    }
+
+    public static class Filters {
+        private Filters() {}; // no public c'tor
+
+        /**
+         * A static convenience function that may be passed as a preFilter parameter
+         * @param <T>
+         * @param element
+         * @return {@code true} if element is not null
+         */
+        public static <T> boolean elementNotNull(T element) {
+            return element != null;
+        }
+
+        /**
+         * A static convenience function that may be passed as a postFilter parameter
+         * @param <R>
+         * @param result
+         * @return {@code true} if result is not null
+         */
+        public static <R> boolean resultNotNull(R result) {
+            return result != null;
+        }
+
+        /**
+         * A static convenience function that may be used with another predicate
+         * to be passed as a preFilter or postFilter parameter
+         * @param <B>
+         * @param predicate The predicate to be negated.
+         * @param arg The parameter to be passed to the predicate.
+         * @return The opposite of what the predicate returns.
+         */
+        public static <B> boolean not(Predicate<B> predicate, B arg) {
+            return predicate.negate().test(arg);
+        }
+
+        /**
+         * A static convenience function that may be used to combine two other predicates
+         * to be passed as a preFilter or postFilter parameter
+         * @param <B>
+         * @param check1 The 1st predicate to be evaluated.
+         * @param check2 The 2nd predicate to be evaluated.
+         * @param arg The parameter to be passed to the predicates.
+         * @return {@code true} only if both predicates are true.
+         */
+        public static <B> boolean and(Predicate<B> check1, Predicate<B> check2, B arg) {
+            return check1.and(check2).test(arg);
+        }
+
+        /**
+         * A static convenience function that may be used to combine two other predicates
+         * to be passed as a preFilter or postFilter parameter
+         * @param <B>
+         * @param check1 The 1st predicate to be evaluated.
+         * @param check2 The 2nd predicate to be evaluated.
+         * @param arg The parameter to be passed to the predicates.
+         * @return {@code true} if either predicate is true.
+         */
+        public static <B> boolean or(Predicate<B> check1, Predicate<B> check2, B arg) {
+            return check1.or(check2).test(arg);
+        }
+
+    }
+
+}

--- a/src/main/java/com/vzome/core/generic/SubClassIterator.java
+++ b/src/main/java/com/vzome/core/generic/SubClassIterator.java
@@ -1,0 +1,43 @@
+package com.vzome.core.generic;
+
+import java.util.function.Predicate;
+
+/**
+ * @author David Hall
+ */
+public class SubClassIterator<T, S extends T> extends FilteredIterator<T, S> {
+    
+    private final Class<S> subClass;
+
+    @Override
+    public boolean preFilter(T element) {
+        return (element != null && subClass.isAssignableFrom(element.getClass()))
+                ? super.preFilter(element)
+                : false;
+    }
+    
+    @Override
+    protected S apply(T element) {
+        return subClass.cast(element);
+    }
+
+    public SubClassIterator(Class<S> subClass, Iterable<T> iterable) {
+        super(iterable);
+        this.subClass = subClass;
+    }
+    
+    public SubClassIterator(Class<S> subClass, Predicate<T> preTest, Iterable<T> iterable) {
+        super(preTest, iterable);
+        this.subClass = subClass;
+    }
+    
+    public SubClassIterator(Class<S> subClass, Iterable<T> iterable, Predicate<S> postTest) {
+        super(iterable, postTest);
+        this.subClass = subClass;
+    }
+    
+    public SubClassIterator(Class<S> subClass, Predicate<T> preTest, Iterable<T> iterable, Predicate<S> postTest) {
+        super(preTest, iterable, postTest);
+        this.subClass = subClass;
+    }
+}

--- a/src/main/java/com/vzome/core/model/Panel.java
+++ b/src/main/java/com/vzome/core/model/Panel.java
@@ -6,19 +6,21 @@ import java.util.Iterator;
 import java.util.List;
 
 import com.vzome.core.algebra.AlgebraicVector;
+import java.util.ArrayList;
 
 public class Panel extends Manifestation implements Iterable<AlgebraicVector>
 {
     private final List<AlgebraicVector> mVertices;
 
     /**
-     * Create a panel from an iterator over AlgebraicVectors
+     * Create a panel from a list of AlgebraicVectors
      * 
      * @param vertices
      */
     public Panel( List<AlgebraicVector> vertices )
     {
-        mVertices = vertices;
+        // copy the list in case the caller modifies it later.
+        mVertices = new ArrayList<>(vertices);
     }
 
     @Override
@@ -40,6 +42,11 @@ public class Panel extends Manifestation implements Iterable<AlgebraicVector>
 	public Iterator<AlgebraicVector> iterator()
 	{
 		return mVertices.iterator();
+	}
+
+	public int getVertexCount()
+	{
+		return mVertices.size();
 	}
 
     @Override
@@ -119,9 +126,7 @@ public class Panel extends Manifestation implements Iterable<AlgebraicVector>
         AlgebraicVector v0 = mVertices.get( 0 );
         AlgebraicVector v1 = mVertices.get( 1 );
         AlgebraicVector v2 = mVertices.get( 2 );
-        v1 = v1 .minus( v0 );
-        v2 = v2 .minus( v0 );
-        return v1 .cross( v2 );
+        return AlgebraicVector.getNormal(v0, v1, v2);
     }
 
 	@Override

--- a/src/test/java/com/vzome/core/editor/ManifestationIteratorTest.java
+++ b/src/test/java/com/vzome/core/editor/ManifestationIteratorTest.java
@@ -1,0 +1,238 @@
+package com.vzome.core.editor;
+
+import com.vzome.core.algebra.AlgebraicField;
+import com.vzome.core.algebra.AlgebraicNumber;
+import com.vzome.core.algebra.AlgebraicVector;
+import com.vzome.core.algebra.PentagonField;
+import com.vzome.core.model.Connector;
+import com.vzome.core.model.Manifestation;
+import com.vzome.core.model.Panel;
+import com.vzome.core.model.Strut;
+import java.util.ArrayList;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import org.junit.Test;
+
+/**
+ * @author David Hall
+ */
+public class ManifestationIteratorTest {
+    
+    @Test
+    public void IteratorTest () {
+        Selection selection = new Selection();
+        AlgebraicField field = new PentagonField();
+        int expC = 0, expS = 0, expP = 0;
+        {
+            ArrayList<Manifestation> cList = new ArrayList<>();
+            AlgebraicNumber s = field .createRational( 7 );
+            AlgebraicNumber t = field .createRational( 6 );
+            AlgebraicNumber u = field .createRational( 5 );
+            AlgebraicNumber v = field .createRational( 4 );
+            AlgebraicNumber w = field .createRational( 3 );
+            AlgebraicNumber x = field .createRational( 2 );
+            AlgebraicNumber y = field .createRational( 1 );
+            AlgebraicNumber z = field .createRational( 0 );
+
+            Connector a = new Connector( new AlgebraicVector(w, x, y) );
+            Connector b = new Connector( new AlgebraicVector(z, w, x) );
+            Connector c = new Connector( new AlgebraicVector(y, z, w) );
+            Connector d = new Connector( new AlgebraicVector(x, y, z) );
+
+            Connector e = new Connector( new AlgebraicVector(s, t, u) );
+            Connector f = new Connector( new AlgebraicVector(v, s, t) );
+            Connector g = new Connector( new AlgebraicVector(u, v, s) );
+            Connector h = new Connector( new AlgebraicVector(t, u, v) );
+            Connector i = new Connector( new AlgebraicVector(t, u, u) );
+            cList .add( a );
+            cList .add( b );
+            cList .add( c );
+            cList .add( d );
+            
+            cList .add( e );
+            cList .add( f );
+            cList .add( g );
+            cList .add( h );
+            cList .add( i );
+            
+            a.setHidden(true);
+            e.setHidden(true);
+            i.setHidden(true);
+
+            expC = cList.size();
+            for(Manifestation m : cList) {
+                selection.select(m);
+            }
+        }
+        {
+            ArrayList<Manifestation> sList = new ArrayList<>();
+            ArrayList<Manifestation> pList = new ArrayList<>();
+            ArrayList<AlgebraicVector> avList = new ArrayList<>();
+            
+            AlgebraicNumber s = field.createRational(7);
+            AlgebraicNumber t = field.createRational(6);
+            AlgebraicNumber u = field.createRational(5);
+            AlgebraicNumber v = field.createRational(4);
+            AlgebraicNumber w = field.createRational(3);
+            AlgebraicNumber x = field.createRational(2);
+            AlgebraicNumber ONE = field.createRational(1);
+            AlgebraicNumber ZERO = field.createRational(0);
+
+            AlgebraicVector ORIGIN = new AlgebraicVector(ZERO, ZERO, ZERO);
+            AlgebraicVector PLUS_X = new AlgebraicVector(ONE, ZERO, ZERO);
+            AlgebraicVector PLUS_Y = new AlgebraicVector(ZERO, ONE, ZERO);
+            AlgebraicVector PLUS_Z = new AlgebraicVector(ZERO, ZERO, ONE);
+            
+            AlgebraicVector a = new AlgebraicVector(w, x, ONE);
+            AlgebraicVector b = new AlgebraicVector(ZERO, w, x);
+            AlgebraicVector c = new AlgebraicVector(ONE, ZERO, w);
+            AlgebraicVector d = new AlgebraicVector(x, ONE, ZERO);
+
+            AlgebraicVector e = new AlgebraicVector(s, t, u);
+            AlgebraicVector f = new AlgebraicVector(v, s, t);
+            AlgebraicVector g = new AlgebraicVector(u, v, s);
+            AlgebraicVector h = new AlgebraicVector(t, u, v);
+            AlgebraicVector i = new AlgebraicVector(t, u, u);
+
+            // TODO: Add a test to be sure that clearing the list 
+            // that we passed to the panel c'tor doesn't change 
+            // the panel's internal list and therefore its hashCode.
+            avList.add(ORIGIN);
+            avList.add(PLUS_X);
+            avList.add(PLUS_Y);
+            pList.add( new Panel(avList));
+            avList.clear();
+
+            // TODO: Add a test that a panel with points in reverse order is still equal
+            // and that starting at a different corner is still equal.
+            // and that hashcode is the same when they are equal.
+            // add a note in the Panel hashcode method to point out 
+            // that the hashcode must be the same for all these conditions.
+            // Make the same tests for panel and polyhedron equality.
+            
+            // TODO: Fix Panel so it calculates the normal correctly if the first three points are collinear.
+            // Add a test for that condition.
+            // TODO: Add a test that the normal is negated when the points are reversed.
+            
+            // TODO: Add the new com.vzome.core.model.Manifestation logger level to the sample logging.properties.
+            
+            // TODO: If normal .isOrigin() in Panel or Face.getNormal(), then log an error or throw an exception. 
+            // This would probably only happen in an invalid test case.
+            
+//            avList.add(ORIGIN);
+//            avList.add(PLUS_Y);
+//            avList.add(PLUS_X);
+//            pList.add( new Panel(avList));
+//            avList.clear();
+
+            avList.add(ORIGIN);
+            avList.add(PLUS_Y);
+            avList.add(PLUS_Z);
+            pList.add( new Panel(avList));
+            avList.clear();
+
+            avList.add(PLUS_Z);
+            avList.add(a);
+            avList.add(b);
+            pList.add( new Panel(avList));
+            avList.clear();
+
+            avList.add(c);
+            avList.add(d);
+            avList.add(e);
+            pList.add( new Panel(avList));
+            avList.clear();
+
+            avList.add(f);
+            avList.add(g);
+            avList.add(h);
+            avList.add(i);
+            pList.add( new Panel(avList));
+            avList.clear();
+            
+            pList.get(0).setHidden(true);
+
+            Strut sa = new Strut(ORIGIN, a);
+            Strut sb = new Strut(ORIGIN, b);
+            Strut sc = new Strut(ORIGIN, c);
+            Strut sd = new Strut(ORIGIN, d);
+
+            Strut se = new Strut(e, ORIGIN);
+            Strut sf = new Strut(f, ORIGIN);
+            Strut sg = new Strut(g, ORIGIN);
+            Strut sh = new Strut(h, ORIGIN);
+            Strut si = new Strut(i, ORIGIN);
+
+            Strut X_AXIS = new Strut(ORIGIN, PLUS_X);
+            Strut Y_AXIS = new Strut(ORIGIN, PLUS_Y);
+            Strut Z_AXIS = new Strut(ORIGIN, PLUS_Z);
+            
+            X_AXIS.setHidden(true);
+            Y_AXIS.setHidden(true);
+            Z_AXIS.setHidden(true);
+
+            sList.add(sa);
+            sList.add(sb);
+            sList.add(sc);
+            sList.add(sd);
+            sList.add(se);
+            sList.add(sf);
+            sList.add(sg);
+            sList.add(sh);
+            sList.add(si);
+            sList.add(X_AXIS);
+            sList.add(Y_AXIS);
+            sList.add(Z_AXIS);
+            
+            for (Manifestation m : sList) {
+                selection.select(m);
+            }
+            expS = sList.size();
+            
+            for (Manifestation m : pList) {
+                selection.select(m);
+            }
+            expP = pList.size();
+        }
+
+        assertTrue(expC > 0);
+        assertTrue(expS > 0);
+        assertTrue(expP > 0);
+        assertTrue(selection.size() > 0);
+        assertEquals(selection.size(), expC + expS + expP);
+
+        int nc = 0;
+        for(Connector connector : Manifestations.getConnectors(selection)) {
+            assertEquals("Connectors: ", connector.getClass(), Connector.class);
+            nc++;
+        }
+        assertTrue(expC > 0);
+        assertEquals(expC, nc);
+        
+        int nv = 0;
+        for(Manifestation man : Manifestations.visibleManifestations(selection)) {
+            nv++;
+        }
+        assertTrue(nv > 0);
+        assertEquals(selection.size() - 7, nv); // we hid 7 of them
+        assertTrue(nv < selection.size());
+        
+        int ns = 0;
+        for(Strut strut : Manifestations.getStruts(selection)) {
+            assertEquals("Struts: ", strut.getClass(), Strut.class);
+            ns++;
+        }
+        assertTrue(expS > 0);
+        assertEquals(expS, ns);
+        
+        int np = 0;
+        for(Panel panel : Manifestations.getPanels(selection)) {
+            assertEquals("Panels: ", panel.getClass(), Panel.class);
+            np++;
+        }
+        assertTrue(expP > 0);
+        assertEquals(expP, np);
+        
+    }
+
+}

--- a/src/test/java/com/vzome/core/model/PanelTest.java
+++ b/src/test/java/com/vzome/core/model/PanelTest.java
@@ -1,0 +1,93 @@
+package com.vzome.core.model;
+
+import com.vzome.core.algebra.AlgebraicField;
+import com.vzome.core.algebra.AlgebraicNumber;
+import com.vzome.core.algebra.AlgebraicVector;
+import com.vzome.core.algebra.PentagonField;
+import java.util.ArrayList;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import org.junit.Test;
+
+/**
+ * @author David Hall
+ */
+public class PanelTest {
+    
+    @Test
+    public void testVerticesAreInvariant() {
+        AlgebraicField field = new PentagonField();
+        AlgebraicNumber w = field.createRational(0);
+        AlgebraicNumber x = field.createRational(1);
+        AlgebraicNumber y = field.createRational(2);
+        AlgebraicNumber z = field.createRational(3);
+        AlgebraicVector a = new AlgebraicVector(w, x, y);
+        AlgebraicVector b = new AlgebraicVector(z, w, x);
+        AlgebraicVector c = new AlgebraicVector(y, z, w);
+        AlgebraicVector d = new AlgebraicVector(x, y, z);
+
+        ArrayList<AlgebraicVector> list = new ArrayList<>();
+        list.add(a);
+        list.add(b);
+        list.add(c);
+        list.add(d);
+        Panel panel = new Panel(list);
+
+        int expected = list.size();
+        assertTrue(expected >= 3);
+        assertEquals(expected, panel.getVertexCount());
+        // be sure the panel's vertex collection can't be changed after the fact.
+        list.clear();
+        assertEquals(expected, panel.getVertexCount());
+    }
+    
+    @Test
+    public void testNormalsMatchVertexOrder() {
+        AlgebraicField field = new PentagonField();
+        
+        AlgebraicNumber ZERO = field.createRational(0);
+        AlgebraicNumber POS1 = field.createRational(181,3982);
+        AlgebraicNumber POS2 = field.createRational(27);
+        AlgebraicNumber POS3 = field.createRational(3555,78);
+        AlgebraicNumber NEG1 = field.createRational(-175);
+        AlgebraicNumber NEG2 = field.createRational(-2,42345690);
+        AlgebraicNumber NEG3 = field.createRational(-324);
+//        AlgebraicVector p = new AlgebraicVector(POS1, ZERO, ZERO);
+//        AlgebraicVector q = new AlgebraicVector(ZERO, POS1, ZERO);
+//        AlgebraicVector r = new AlgebraicVector(ZERO, ZERO, POS1);
+        AlgebraicVector p = new AlgebraicVector(NEG3, ZERO, POS2);
+        AlgebraicVector q = new AlgebraicVector(ZERO, POS1, POS3);
+        AlgebraicVector r = new AlgebraicVector(NEG1, NEG2, POS1);
+
+        ArrayList<AlgebraicVector> list = new ArrayList<>();
+        list.add(p);
+        list.add(q);
+        list.add(r);
+        Panel p0 = new Panel(list);
+
+        int size = list.size();
+        assertTrue(size >= 3);
+        
+        AlgebraicVector n0 = p0.getNormal();
+        assertFalse(n0.isOrigin());
+        
+//        list.add(1, list.remove(0)); // swap first two
+        list.add(2, list.remove(1)); // swap last two
+        
+        Panel p1 = new Panel(list);
+        assertEquals(size, list.size());
+        
+        AlgebraicVector n1 = p1.getNormal();
+        assertFalse(n1.isOrigin());
+        
+        // normals should be equal but opposite directions.
+        // so adding them should equal zero
+        AlgebraicVector sum = n0.plus(n1);
+        assertTrue(sum.isOrigin());
+        
+        // TODO: Make a specific panel with a known normal and be sure the direction is as expected for the right hand rule 
+        //  or at leaast backward compatible with earlier versions...
+    }
+    
+}


### PR DESCRIPTION
Scott,

Here's the cleaned up and refactored version of the 3 new commands I sent last week. I deleted the old branch so there's no confusion. I'll send a corresponding pull request for vzome-desktop in a few minutes.

* Select Parallel, Collinear or Automatic struts.
* Add new FilteredIterator and SubClassIterator classes.
* Add new Manifestations class to provide common iterations and filters.
* Add new ChangeSelection and ChangeManifestation constructors which provide a default groupInSelection.
* Add getNormal and areCollinear static AlgebraicVector methods
* Copy vertices in Panel c'tor so caller can't change them later.
* Enable more verbose compiler warnings
* Add more tests for Panel
* Make a few more variables final.