### PR TITLE
Only call importNode() when necessary

### DIFF
--- a/src/main/java/com/vzome/core/editor/EditHistory.java
+++ b/src/main/java/com/vzome/core/editor/EditHistory.java
@@ -469,7 +469,9 @@ public class EditHistory implements Iterable<UndoableEdit>
                 <StrutCreation anchor="0 0 0 0 0 0" index="9" len="2 4"/>
               </EditHistory>
             */
-            return (Element) doc.importNode(xml, true);
+            return ( doc.equals( xml.getOwnerDocument() ) )
+                    ? xml
+                    : (Element) doc.importNode(xml, true);
         }
 
         @Override


### PR DESCRIPTION
Sorry, I didn't get this last commit in before you pulled the previous one. This is just a minor optimization that also helps clarify why importNode() is needed.