### PR TITLE
Rename equals() to hasEquivalentParameters() in 4 tools

### DIFF
--- a/src/main/java/com/vzome/core/editor/BookmarkTool.java
+++ b/src/main/java/com/vzome/core/editor/BookmarkTool.java
@@ -34,8 +34,9 @@ public class BookmarkTool extends ChangeManifestations implements Tool
         }
     }
 
-	@Override
-	public boolean equals( Object that )
+	// Not quite the same as overriding equals since the tool name is not compared
+    // We're basically just checking if the tool's input parameters match
+	public boolean hasEquivalentParameters( Object that )
 	{
 		if (this == that) {
 			return true;

--- a/src/main/java/com/vzome/core/editor/LinearMapTool.java
+++ b/src/main/java/com/vzome/core/editor/LinearMapTool.java
@@ -29,8 +29,9 @@ public class LinearMapTool extends TransformationTool
         this.originalScaling = originalScaling;
     }
 
-	@Override
-	public boolean equals( Object that )
+	// Not quite the same as overriding equals since the tool name is not compared
+    // We're basically just checking if the tool's input parameters match
+	public boolean hasEquivalentParameters( Object that )
 	{
 		if (this == that) {
 			return true;

--- a/src/main/java/com/vzome/core/editor/ModuleTool.java
+++ b/src/main/java/com/vzome/core/editor/ModuleTool.java
@@ -32,8 +32,9 @@ public class ModuleTool extends ChangeManifestations implements Tool
         mSelection .copy( bookmarkedSelection );
     }
 
-	@Override
-	public boolean equals( Object that )
+	// Not quite the same as overriding equals since the tool name is not compared
+    // We're basically just checking if the tool's input parameters match
+	public boolean hasEquivalentParameters( Object that )
 	{
 		if (this == that) {
 			return true;

--- a/src/main/java/com/vzome/core/editor/PlaneSelectionTool.java
+++ b/src/main/java/com/vzome/core/editor/PlaneSelectionTool.java
@@ -44,8 +44,9 @@ public class PlaneSelectionTool extends ChangeSelection implements Tool
         this .tools = tools;
     }
 
-	@Override
-	public boolean equals( Object that )
+	// Not quite the same as overriding equals since the tool name is not compared
+    // We're basically just checking if the tool's input parameters match
+	public boolean hasEquivalentParameters( Object that )
 	{
 		if (this == that) {
 			return true;


### PR DESCRIPTION
These methods are not quite the same as overriding equals() since the tool name is not compared. Since we're basically just checking if the tool's input parameters match, I renamed equals() to hasEquivalentParameters() to avoid the compiler warning about equals() being overridden without hashcode() being overriden too.

Since these methods no longer overload equals(), any collections or other code that may be calling equals() will now be using object.equals() , not hasEquivalentParameters().