### PR TITLE
Deprecate enableFrameLabels() and disableFrameLabels()

### DIFF
--- a/src/main/java/com/vzome/core/render/RenderingChanges.java
+++ b/src/main/java/com/vzome/core/render/RenderingChanges.java
@@ -23,8 +23,20 @@ public interface RenderingChanges {
     void orientationChanged( RenderedManifestation manifestation );
 
     void shapeChanged( RenderedManifestation manifestation );
-	
-    public void enableFrameLabels();
-    
-    public void disableFrameLabels();
+
+    /**
+    * @deprecated As of 7/20/2016: Use controller property "showFrameLabels" instead.
+    */
+    @Deprecated
+    default void enableFrameLabels(){
+        throw new IllegalStateException( "enableFrameLabels is deprecated." );
+    }
+
+    /**
+    * @deprecated As of 7/20/2016: Use controller property "showFrameLabels" instead.
+    */
+    @Deprecated
+    default void disableFrameLabels(){
+        throw new IllegalStateException( "disableFrameLabels is deprecated." );
+    }
 }

--- a/src/main/java/com/vzome/core/render/TransparentRendering.java
+++ b/src/main/java/com/vzome/core/render/TransparentRendering.java
@@ -68,10 +68,4 @@ public class TransparentRendering implements RenderingChanges
         throw new IllegalStateException();
     }
 
-    @Override
-    public void enableFrameLabels() {}
-
-    @Override
-    public void disableFrameLabels() {}
-    
 }


### PR DESCRIPTION
I know you said you'd do this pert, but I got impatient. I wanted my new stuff to be based on already having this change made. It should be OK since it's based on a version of core that's not a desktop dependency yet.

* Provide default implementation so derived classes are no longer required to implement it.
* Use controller property "showFrameLabels" instead.