### PR TITLE
Add new import features to VEF format version 7

### DIFF
--- a/src/main/java/com/vzome/core/commands/CommandImportVEFData.java
+++ b/src/main/java/com/vzome/core/commands/CommandImportVEFData.java
@@ -153,7 +153,9 @@ public class CommandImportVEFData extends AbstractCommand
         @Override
         protected void addVertex( int index, AlgebraicVector location )
         {
-            location = location .scale( scale );
+            if ( scale != null && ! usesActualScale() ) {
+                location = location .scale( scale );
+            }
             if ( mProjection != null )
                 location = mProjection .projectImage( location, wFirst() );
             mVertices[ index ] = new FreePoint( location );

--- a/src/main/java/com/vzome/core/construction/VefToModel.java
+++ b/src/main/java/com/vzome/core/construction/VefToModel.java
@@ -63,7 +63,7 @@ public class VefToModel extends VefParser
     protected void addVertex( int index, AlgebraicVector location )
     {
         logger .finest( "addVertex location = " + location .getVectorExpression( AlgebraicField .VEF_FORMAT ) );
-        if ( scale != null )
+        if ( scale != null && ! usesActualScale())
         {
             location = location .scale( scale );
             logger .finest( "scaled = " + location .getVectorExpression( AlgebraicField .VEF_FORMAT ) );

--- a/src/main/java/com/vzome/core/math/VefParser.java
+++ b/src/main/java/com/vzome/core/math/VefParser.java
@@ -10,9 +10,17 @@ import com.vzome.core.algebra.AlgebraicField;
 import com.vzome.core.algebra.AlgebraicNumber;
 import com.vzome.core.algebra.AlgebraicVector;
 import com.vzome.core.algebra.BigRational;
+import java.util.Stack;
 
 public abstract class VefParser
 {
+    // Version 7 supports:
+    // New "rational" field which requires only rational numbers as input and matches any actual field
+    // Mix of rational and/or irrational numeric format for parsing scale and vertices
+    // Factors not specified in the VEF string will be set to 0 so they don't all have to be listed.
+    // Flag telling subclasses to use the specified scale and not introduce additional scaling after parsing.
+    public static final int VERSION_RATIONAL_ACTUAL_SCALE = 7;
+
     public static final int VERSION_EXPLICIT_BALLS = 6;
     
     public static final int VERSION_ANY_FIELD = 5;
@@ -21,8 +29,12 @@ public abstract class VefParser
     
     private int mVersion = 0;
     
+    private boolean isRational = false;
+
+    private boolean useActualScale = false;
+
     private transient AlgebraicField field, subfield;
-    
+
     protected abstract void startVertices( int numVertices );
     
     protected abstract void addVertex( int index, AlgebraicVector location );
@@ -57,6 +69,16 @@ public abstract class VefParser
         return this .field;
     }
     
+    protected boolean isRational()
+    {
+        return isRational;
+    }
+
+    public boolean usesActualScale()
+    {
+        return useActualScale;
+    }
+
     protected boolean wFirst()
     {
         return mVersion >= VERSION_W_FIRST;
@@ -74,6 +96,8 @@ public abstract class VefParser
             throw new IllegalStateException( "VEF format error: no tokens in file data: \"" + vefData + "\"" );
         }
         mVersion = 0;
+        isRational = false;
+        useActualScale = false;
         AlgebraicNumber scale = field .createAlgebraicNumber( 1, 0, 1, 0 );
         if ( token .equals( "vZome" ) ) {
             // format 4, with version number
@@ -103,6 +127,11 @@ public abstract class VefParser
             } catch ( NoSuchElementException e1 ) {
                 throw new IllegalStateException( "VEF format error: no tokens after \"field\"" );
             }
+            // format >= 7 allows "rational" to match any field since it is a subset of every other field
+            if ( token .equals( "rational" ) ) {
+                isRational = true;
+                token = field .getName();
+            }
             if ( token .equals( field .getName() ) )
                 subfield = field;
             else if ( subfield == null )
@@ -116,6 +145,16 @@ public abstract class VefParser
         }
         else
             subfield = field;
+
+        // format >= 7 allows disabling subsequent scaling with keyword "actual"
+        if ( token .equals( "actual" ) ) {
+            try {
+                useActualScale = true;
+                token = tokens .nextToken();
+            } catch ( NoSuchElementException e1 ) {
+                throw new IllegalStateException( "VEF format error: no tokens after \"actual\"" );
+            }
+        }
         
         if ( token .equals( "scale" ) ) {
             try {
@@ -245,39 +284,64 @@ public abstract class VefParser
     
     private AlgebraicNumber parseIntegralNumber( String string )
     {
-        BigRational[] factors = new BigRational[ this .field .getOrder() ];
-        // strip "(" and ")", tokenize on ","
-        StringTokenizer tokens = new StringTokenizer( string .substring( 1, string .length()-1 ), "," );
-        for ( int i = subfield .getOrder() - 1; i >= 0; i-- )
-        {
-            String coord = null;
-            try {
-                coord = tokens .nextToken();
-            } catch ( NoSuchElementException e ) {
-                throw new IllegalStateException( "VEF format error: not enough coordinates for field: \"" + string + "\"" );
+        BigRational[] factors = new BigRational[this.field.getOrder()];
+        // if the field is declared as rational, then we won't allow the irrational syntax using parenthesis
+        // if the field is NOT declared as rational, then we will still allow the rational format as shorthand with no parenthesis
+        // or we will allow any order N string representation where N <= field.getOrder().
+        if( (!isRational) &&  string.startsWith("(") && string.endsWith(")") ) {
+            // strip "(" and ")", tokenize on ","
+            StringTokenizer tokens = new StringTokenizer(string.substring(1, string.length() - 1), ",");
+            // The tokens get pushed into the factors array in reverse order 
+            // from the string representation so the last token becomes the 0th factor.
+            // For example, with an order 2 field, the factors for "(3,-2)" are parsed to a 2 element array as {-2, 3}
+            // With an order 6 field such as the snubDodec, the factors for "(0,0,0,0,3,-2)" are parsed to a 6 element array: {-2, 3, 0, 0, 0, 0}
+            // When a field needs more factors than are supplied, the factors that are provided must still be parsed into the begining of the array:
+            // With an order 6 field, if only 2 factors are provided, "(3,-2)" must still be parsed into a 6 element array as {-2, 3, 0, 0, 0, 0}
+            // Since VEF version 7 no longer requires that all factors be provided, we need to push the factors onto a stack
+            // and pop them off to reverse the order as they are inserted into the begining of the factors array.
+            Stack<BigRational> stack = new Stack<>();
+            while(tokens.hasMoreElements()) {
+                if(stack.size() >= field.getOrder()) {
+                    throw new RuntimeException( "VEF format error: \"" + string + "\" has too many factors for " + field.getName() + " field" );
+                }
+                stack.push( parseRationalNumber( tokens.nextToken() ) );
             }
-
-            int num = 0, denom = 1;
-            int slash = coord .indexOf( '/' );
-            if ( slash > 0 ) {
-                try {
-                    num = Integer .parseInt( coord .substring( 0, slash ) );
-                } catch ( NumberFormatException e ) {
-                    throw new RuntimeException( "VEF format error: rational numerator (\"" + coord + "\") must be an integer", e );
-                }
-                try {
-                    denom = Integer .parseInt( coord .substring( slash+1 ) );
-                } catch ( NumberFormatException e ) {
-                    throw new RuntimeException( "VEF format error: rational denominator (\"" + coord + "\") must be an integer", e );
-                }
-            } else
-                try {
-                    num = Integer .parseInt( coord );
-                } catch ( NumberFormatException e ) {
-                    throw new RuntimeException( "VEF format error: coordinate value (\"" + coord + "\") must be an integer or rational", e );
-                }
-            factors[ i ] = new BigRational( num, denom );
+            int i = 0;
+            while(! stack.empty() ) {
+               factors[i++] = stack.pop();
+            }
+            return this.field.createAlgebraicNumber(factors);
+        } else {
+            // format >= 7 supports the rational numeric format which expects no irrational factors,
+            // so there are no parentheses or commas, but still allows the optional "/" if a denominator is specified.
+            factors[0] = parseRationalNumber( string );
+            // count on createAlgebraicNumber to set all of the null irrational factors to zero
         }
-        return this .field .createAlgebraicNumber( factors );
+        return this.field.createAlgebraicNumber(factors);
+    }
+
+    private BigRational parseRationalNumber( String coord )
+    {
+        int num = 0, denom = 1;
+        int slash = coord .indexOf( '/' );
+        if ( slash > 0 ) {
+            try {
+                num = Integer .parseInt( coord .substring( 0, slash ) );
+            } catch ( NumberFormatException e ) {
+                throw new RuntimeException( "VEF format error: rational numerator (\"" + coord + "\") must be an integer", e );
+            }
+            try {
+                denom = Integer .parseInt( coord .substring( slash+1 ) );
+            } catch ( NumberFormatException e ) {
+                throw new RuntimeException( "VEF format error: rational denominator (\"" + coord + "\") must be an integer", e );
+            }
+        } else {
+            try {
+                num = Integer .parseInt( coord );
+            } catch ( NumberFormatException e ) {
+                throw new RuntimeException( "VEF format error: coordinate value (\"" + coord + "\") must be an integer or rational", e );
+            }
+        }
+        return new BigRational( num, denom );
     }
 }

--- a/src/test/java/com/vzome/core/algebra/AlgebraicNumberTest.java
+++ b/src/test/java/com/vzome/core/algebra/AlgebraicNumberTest.java
@@ -26,6 +26,23 @@ public class AlgebraicNumberTest extends TestCase
         }
     }
 
+    public void testZeroPower()
+    {
+        AlgebraicField pentagonField = new PentagonField();
+        final AlgebraicField[] fields = {
+            pentagonField,
+            new RootTwoField(),
+            new RootThreeField(),
+            new HeptagonField(),
+            new SnubDodecField(pentagonField)
+        };
+        for(AlgebraicField field : fields ) {
+            AlgebraicNumber one = field.createPower(0); // anything to the zero power...
+            assertEquals(one, field.createRational(1)); // ...equals exactly one
+            assertTrue(one.isOne());
+        }
+    }
+
     public void testFactorsNotNull()
     {
         final AlgebraicField field = new PentagonField();

--- a/src/test/java/com/vzome/core/construction/VefToModelTest.java
+++ b/src/test/java/com/vzome/core/construction/VefToModelTest.java
@@ -5,14 +5,263 @@ package com.vzome.core.construction;
 
 import java.util.ArrayList;
 
-import junit.framework.TestCase;
-
 import com.vzome.core.algebra.AlgebraicField;
+import com.vzome.core.algebra.AlgebraicNumber;
 import com.vzome.core.algebra.AlgebraicVector;
+import com.vzome.core.algebra.BigRational;
+import com.vzome.core.algebra.HeptagonField;
+import com.vzome.core.algebra.PentagonField;
+import com.vzome.core.algebra.RootThreeField;
 import com.vzome.core.algebra.RootTwoField;
+import com.vzome.core.algebra.SnubDodecField;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.fail;
+import org.junit.Test;
 
-public class VefToModelTest extends TestCase
+public class VefToModelTest
 {
+    @Test
+    public void testAutomaticField() {
+        final AlgebraicVector quaternion = null;
+        final NewConstructions effects = new NewConstructions();
+        final AlgebraicVector offset = null;
+        // we're testing that the keyword "automatic" here can be applied to all types of AlgebraicField
+        final String vefData = "vZome VEF 7 field rational "
+                + "actual scale 1 "
+                + "3 "
+                + "0 0 0 0 "
+                + "0 1 2 3 "
+                + "4 5 6 7 "
+                ;
+        
+        final AlgebraicField pentagonField = new PentagonField();
+        final AlgebraicField[] fields = { 
+            pentagonField, 
+            new RootTwoField(), 
+            new RootThreeField(), 
+            new HeptagonField(), 
+            new SnubDodecField( pentagonField ),
+        };
+
+        int testsPassed = 0;
+        try {
+            for(AlgebraicField field : fields ) {
+                effects.clear();
+                AlgebraicNumber scale = field.createPower(0);
+                assertTrue(scale.isOne());
+                VefToModel parser = new VefToModel(quaternion, effects, scale, offset);
+                parser.parseVEF(vefData, field);
+                assertEquals(effects.size(), 3);
+                testsPassed++;
+            }
+        }
+        catch(Exception ex) {
+            fail(ex.toString());
+        }
+        assertEquals(testsPassed, 5);
+    }
+
+    @Test
+    public void testScaling() {
+        final AlgebraicVector quaternion = null;
+        final NewConstructions effects = new NewConstructions();
+        final AlgebraicVector offset = null;
+        final AlgebraicField field = new RootTwoField();
+
+        AlgebraicNumber scale = field.createPower(6); // rootTwo^6 = 2^3 = 8
+        assertEquals(scale, field.createRational(8));
+
+        VefToModel parser = new VefToModel(quaternion, effects, scale, offset);
+
+        String vefData = "vZome VEF 7 field rootTwo "
+                + "actual scale 1 "
+                + "3 "
+                + "0 0 0 0 "
+                + "0 1 2 3 "
+                + "4 5 6 7 "
+                ;
+
+        // The scale parameter passed to parser should be ignored for now
+        // because of the keyword "actual" in vefData
+        AlgebraicVector expected = field.createVector(new int[] {
+            1, 1, 0, 1,  
+            2, 1, 0, 1,  
+            3, 1, 0, 1
+        });
+        parser.parseVEF(vefData, field);
+        assertTrue(parser.usesActualScale());
+        Point p0 = (Point) effects.get(1);
+        AlgebraicVector v0 = p0.getLocation();
+        assertEquals(expected, v0);
+
+        // The scale parameter passed to parser is still being ignored
+        // because of the keyword "actual" in vefData
+        // but the scale in vefData is changed to 3, so we multiply our expected value by 3 as well.
+        vefData = vefData.replace("scale 1 ", "scale 3 ");
+        expected = expected.scale(field.createRational(3));
+        effects.clear();
+        parser.parseVEF(vefData, field);
+        assertTrue(parser.usesActualScale());
+        p0 = (Point) effects.get(1);
+        v0 = p0.getLocation();
+        assertEquals(expected, v0);
+
+        // Now we'll allow the parser to apply its scale parameter
+        // by removing the keyword "actual" from vefData
+        // so we must also multiply our expected value by scale, which is 8.
+        vefData = vefData.replace("actual ", "");
+        expected = expected.scale(scale);
+        effects.clear();
+        parser.parseVEF(vefData, field);
+        assertFalse(parser.usesActualScale());
+        p0 = (Point) effects.get(1);
+        v0 = p0.getLocation();
+        assertEquals(expected, v0);
+
+        // just to be sure we ended up where we expected to be...
+        assertEquals(expected, field.createVector(new int[] {
+            3*8*1, 1, 0, 1,
+            3*8*2, 1, 0, 1,
+            3*8*3, 1, 0, 1
+        }));
+    }
+
+    @Test
+    public void testMixedVectorFormat()
+    {
+        final AlgebraicVector quaternion = null;
+        final NewConstructions effects = new NewConstructions();
+        final AlgebraicVector offset = null;
+        final AlgebraicField pentagonField = new PentagonField();
+        final AlgebraicField[] fields = {
+            pentagonField,
+            new RootTwoField(),
+            new RootThreeField(),
+            new HeptagonField(),
+            new SnubDodecField( pentagonField ),
+       };
+
+        int testsPassed = 0;
+        // Verify that a mix of integer and rational formatted values can be parsed
+        final String vefData = "vZome VEF 7 field rational "
+                + "actual scale 1 "
+                + "3 "
+                + "0 -2 3 4 " // all integers
+                + "0 123/456 -7/-8 -9/10 " // all rational
+                + "0/1 0/9999 5/5 12/-6 " // some unreduced fractions
+                ;
+
+        try {
+            for(AlgebraicField field : fields ) {
+                effects.clear();
+
+                AlgebraicVector expected[] = new AlgebraicVector[] {
+                    new AlgebraicVector( field.createRational(-2),      field.createRational(3),    field.createRational(4)    ),
+                    new AlgebraicVector( field.createRational(123,456), field.createRational(7,8),  field.createRational(-9,10) ),
+                    new AlgebraicVector( field.createRational(0),       field.createRational(1),    field.createRational(-2) ),
+                };
+                AlgebraicNumber scale = field.createRational(1);
+                VefToModel parser = new VefToModel(quaternion, effects, scale, offset);
+                parser.parseVEF(vefData, field);
+                assertEquals(effects.size(), expected.length);
+                for( int i = 0; i < effects.size(); i++) {
+                    Point p1 = (Point) effects.get(i);
+                    AlgebraicVector v1 = p1.getLocation();
+                    assertEquals( expected[i], v1 ); // the expected value was parsed
+                    // now be sure the irrational elements are all zero and not null
+                    for(int dim = 0; dim < v1.dimension(); dim++) {
+                        AlgebraicNumber n1 = v1.getComponent(dim);
+                        BigRational[] factors = n1.getFactors();
+                        assertEquals( factors.length, field.getOrder() );
+                        for( int f = 1; f < factors.length; f++ ) {
+                            assertTrue(factors[f] != null);
+                            assertTrue(factors[f].isZero());
+                        }
+                    }
+                    testsPassed++;
+                }
+            }
+        }
+        catch(Exception ex) {
+            fail(ex.toString());
+        }
+        assertEquals(testsPassed, 3 * fields.length );
+        assertTrue( testsPassed > 0 );
+    }
+
+    @Test
+    public void testZeroFillHigherOrderIrrationals() {
+        // TODO: Be sure that an order N formatted number can be imported into a field of order > N
+        // with the resulting irrational factors automatically zero filled.
+        // Also confirm that specifying too many factors for a field will generate an error.
+
+                final AlgebraicVector quaternion = null;
+        final NewConstructions effects = new NewConstructions();
+        final AlgebraicVector offset = null;
+        final AlgebraicField pentagonField = new PentagonField();
+        final AlgebraicField[] fields = {
+            pentagonField,                          // order 2
+            new RootTwoField(),                     // order 2
+            new RootThreeField(),                   // order 2
+            new HeptagonField(),                    // order 3
+            new SnubDodecField( pentagonField ),    // order 6
+       };
+
+        int testsPassed = 0;
+        // Verify that a mix of integer and order 2 irrational formatted values can be parsed by all fields of order > 2
+        final String vefData = "vZome VEF 7 field $$$ "
+                + "actual scale 1 "
+                + "1 "
+                + "0 (-2,3) (4,5) 6/7" // mix of order 2 and rational
+                // VEF format has one rational factor on the right and all irrationals on the left
+                ;
+
+        try {
+            for(AlgebraicField field : fields ) {
+                effects.clear();
+                AlgebraicVector expected[] = new AlgebraicVector[] {
+                    new AlgebraicVector(
+                            field.createRational( 3 ).plus( field.createPower(1).times(field.createRational(-2 )) ),
+                            field.createRational( 5 ).plus( field.createPower(1).times(field.createRational( 4 )) ),
+                            field.createRational( 6, 7 )
+                    )
+                };
+                AlgebraicNumber scale = field.createRational(1);
+                VefToModel parser = new VefToModel(quaternion, effects, scale, offset);
+                parser.parseVEF(vefData.replace("$$$", field.getName()), field);
+                assertEquals(effects.size(), expected.length);
+                for( int i = 0; i < effects.size(); i++) {
+                    Point p1 = (Point) effects.get(i);
+                    AlgebraicVector v1 = p1.getLocation();
+                    assertEquals( expected[i], v1 ); // the expected value was parsed
+                    // now be sure the irrational elements are not null
+                    for(int dim = 0; dim < v1.dimension(); dim++) {
+                        AlgebraicNumber n1 = v1.getComponent(dim);
+                        BigRational[] factors = n1.getFactors();
+                        assertEquals( factors.length, field.getOrder() );
+                        for( int f = 0; f < factors.length; f++ ) {
+                            assertTrue(factors[f] != null);
+                            // rational factor is at f=0, 1st irrational is at f=1, all other factors should be set to 0.
+                            if(f >= 2) {
+                                // be sure the irrational elements > order 2 are zero
+                                assertTrue(factors[f].isZero());
+                            }
+                        }
+                    }
+                    testsPassed++;
+                }
+            }
+        }
+        catch(Exception ex) {
+            fail(ex.toString());
+        }
+        assertEquals( testsPassed, fields.length );
+        assertTrue( testsPassed > 0 );
+    }
+
+    @Test
     public void testParse()
     {
         AlgebraicField field = new RootTwoField();


### PR DESCRIPTION
* New "rational" field automatically uses field of current model
* The rational field allows only rational numeric format
* All other fields allow any mix of both rational and irrational numeric formats
* Order N fields can specify fewer than N factors and all unspecified factors will default to 0.
* Optional scale override keyword "actual"
* Add supporting test cases