### PR TITLE
Print warning when regression tests are skipped

### DIFF
--- a/src/regression/java/com/vzome/core/regression/TestVZomeFiles.java
+++ b/src/regression/java/com/vzome/core/regression/TestVZomeFiles.java
@@ -216,7 +216,14 @@ public class TestVZomeFiles extends FileSystemVisitor2 .Actor
                     } finally {
                         histOut .close();
                     }
-                    Process process = Runtime .getRuntime() .exec( "diff " + goldenHistory .getAbsolutePath() + " " + testHistory .getAbsolutePath() );
+                    // Note that the diff command is not native on Windows,
+                    // but c:\windows\system32\fc.exe can be copied to a folder in the PATH and named diff.exe
+                    // and this test will at least be able to run,
+                    // although the resulting xml file will probably be different than on the Mac
+                    
+                    // Wrap the file names in quotes in case they have embedded spaces
+                    String cmd = "diff \"" + goldenHistory .getAbsolutePath() + "\" \"" + testHistory .getAbsolutePath() + "\"";
+                    Process process = Runtime .getRuntime() .exec( cmd );
                     // any error message?
                     StreamGobbler errorGobbler = new 
                         StreamGobbler( process.getErrorStream(), "ERROR" );            

--- a/src/regression/java/com/vzome/core/regression/TestVZomeFiles.java
+++ b/src/regression/java/com/vzome/core/regression/TestVZomeFiles.java
@@ -235,6 +235,9 @@ public class TestVZomeFiles extends FileSystemVisitor2 .Actor
                         throw new Exception( "ExitValue: " + exitVal );
                     else
                         testHistory .delete();
+                } 
+                else {
+                    System .out .println( "Test skipped. No goldenHistory found at " + goldenHistory .getAbsoluteFile() );
                 }
             } catch ( Exception e ) {
                 Element error = new Element( "error" );


### PR DESCRIPTION
I had to laugh at myself when I realized that the regression tests had never actually been run on my computer because I normally run the gradle "regression" task and make sure the whole suite runs clean before submitting a PR for anything except the most trivial changes. Apparently, it wasn't testing what I thought it was testing.

Today was the first time I actually set a breakpoint in the code and discovered that it wasn't being executed, so I added this warning for future reference.

I realized that I still can't just add the missing golden history files and run the tests because I realized that the tests exec "diff", which is not built in to Windows. No big deal for now, but at least it's clear when the test are not being run. Maybe I'll look into finding a command line diff program for Windows.

I figured that you might inadvertently have the same scenario of unknowingly skipping a test file if you had any of the history files missing, so hopefully this will be useful to you as well to make the test just a little more robust.